### PR TITLE
Fix cross-turn recall (find + return past content) + mid-turn input echo

### DIFF
--- a/src/memagent/history.py
+++ b/src/memagent/history.py
@@ -19,11 +19,15 @@ from __future__ import annotations
 
 from .text_utils import format_ts
 
-INDEX_LIMIT = 40       # breadcrumbs shown by the bare index
-TRACE_MAX = 4000       # total chars for a compact-trace fetch
-FULL_MAX = 8000        # total chars for a full-slice fetch
-OBS_TAIL = 300         # per-observation tail kept in a trace
-DISTINCT_PER_TURN = 8  # generous backstop on DISTINCT turn-fetches; repeats are redirected for free
+INDEX_LIMIT = 40       # breadcrumbs shown by the bare index (a LOCATOR bound — titles/notes, not content)
+OBS_TAIL = 300         # legacy-record fallback ONLY: per-observation tail when there is no stored markdown
+DISTINCT_PER_TURN = 8  # backstop on DISTINCT turn-fetches per turn; repeats are redirected for free
+# NO read-side CONTENT cap: a fetched turn is returned IN FULL. The bound is the SEAL, not a second cut at
+# read — the archive already excerpts observations at SAVE time (episode._obs_excerpt), a fetched turn is
+# TRANSIENT (enters context for this loop only, never written back to slice state, so recall can't rebuild
+# the transcript across loops), and the physical context window + overflow is the size backstop for a
+# deliberate sweep. The old 4000/8000 caps cut the distilled CONCLUSION — the one thing recall exists to
+# return — because the conclusion is appended LAST in the markdown (bound = the seal, not a within-loop cut).
 
 CAPTURE_BACK = ("\n\n↳ Now in context. Record what you need with a `note`, then continue — and "
                 "fetch another turn from PAGED-OUT HISTORY whenever you need more.")
@@ -68,18 +72,20 @@ def render_index(lines: list[dict]) -> str:
     return "\n".join(out)
 
 
-def render_trace(lines: list[dict], cap: int = TRACE_MAX) -> str:
-    """Page a sealed turn back as its clean MARKDOWN snapshot (the seal artifact) — a smooth read, like
-    opening a readable doc. Falls back to a computed action→result trace for older records that predate
-    the stored markdown."""
+def render_trace(lines: list[dict]) -> str:
+    """Page sealed turns back as their clean MARKDOWN snapshot (the seal artifact) — returned IN FULL, no
+    read-side size cap (see the constants note: the bound is the seal + transience, not a second read cut;
+    a cap here truncated the distilled conclusion at the markdown tail). Falls back to a computed
+    action→result trace for older records that predate the stored markdown (per-observation tail only — a
+    legacy raw-obs guard; the conclusion/note is kept whole)."""
     from .tool_summary import summarize_tool_result   # fallback path only
-    out, used = [], 0
+    out = []
     for ln in lines:
         rec = ln.get("record", {})
         head = f"\n── turn {ln.get('turn')} · {_short_ts(ln.get('ts',''))} · {rec.get('title') or ''}"
         md = rec.get("markdown")
-        if md:                                   # the SEAL artifact — return it directly (smooth read)
-            chunk = head + "\n" + md
+        if md:                                   # the SEAL artifact — return it directly, in full
+            out.append(head + "\n" + md)
         else:                                    # older record without a stored markdown → compute a trace
             block = [head]
             for st in rec.get("steps", []):
@@ -88,28 +94,22 @@ def render_trace(lines: list[dict], cap: int = TRACE_MAX) -> str:
                                                     failing=bool(a.get("failing")))
                     block.append(f"  • {summary} → {_tail(o, OBS_TAIL)}")
             if rec.get("note"):
-                block.append(f"  ↳ note: {rec['note'][:200]}")
-            chunk = "\n".join(block)
-        if used + len(chunk) > cap:
-            out.append("\n…[older turns truncated — narrow with turns=[…]]")
-            break
-        out.append(chunk)
-        used += len(chunk)
+                block.append(f"  ↳ note: {rec['note']}")     # conclusion in full
+            out.append("\n".join(block))
     return "\n".join(out).strip() or "(no trace)"
 
 
-def render_full(lines: list[dict], cap: int = FULL_MAX) -> str:
-    out, used = [], 0
+def render_full(lines: list[dict]) -> str:
+    out = []
     for ln in lines:
         rec = ln.get("record", {})
         slices = [st.get("slice", "") for st in rec.get("steps", []) if st.get("slice")]
         body = (slices[-1] if slices else "")   # the turn's last reconstructed slice = its end state
+        note = rec.get("note") or ""
         chunk = f"\n══ turn {ln.get('turn')} · {_short_ts(ln.get('ts',''))} · {rec.get('title') or ''}\n{body}"
-        if used + len(chunk) > cap:
-            out.append("\n…[truncated — fetch fewer turns for full slices]")
-            break
+        if note:                                # the agent's REPLY/conclusion lives in the note, NOT the seed
+            chunk += f"\n\n## conclusion\n{note}"   # slice — without this, 'full' never returned the findings
         out.append(chunk)
-        used += len(chunk)
     return "\n".join(out).strip() or "(no slice stored)"
 
 

--- a/src/memagent/search_index.py
+++ b/src/memagent/search_index.py
@@ -40,11 +40,15 @@ _FTS_TABLE = "episodes"
 
 
 def _fts_match_query(q: str) -> str:
-    """#40: turn a free-text query into a SAFE FTS5 MATCH expression. Extract word tokens only and quote
-    each (a bag of literal terms, AND-ed — FTS5's default) so query punctuation/operators (- " * : ( )
-    AND OR NEAR) can never trigger a syntax error that silently returns nothing. Empty → '' (no search)."""
+    """Turn a free-text query into a SAFE FTS5 MATCH expression. Extract word tokens only and quote each
+    (so query punctuation/operators - " * : ( ) AND OR NEAR can never trigger a syntax error that silently
+    returns nothing), then OR-join them. OR (not AND) is the recall-correct default: a query carries terms
+    the target turn won't all contain — meta/ordinal words ("second", "finding"), the user's own framing,
+    stray operators — and AND-joining means ONE absent token zeroes the whole result (the 'can't locate my
+    second finding' bug: 'second' appeared in no review turn, so the AND failed). With OR, any term surfaces
+    the turn and BM25 rank + the relative floor in search() keep it precise. Empty → '' (no search)."""
     toks = re.findall(r"\w+", q or "", flags=re.UNICODE)
-    return " ".join(f'"{t}"' for t in toks)
+    return " OR ".join(f'"{t}"' for t in toks)
 
 
 def fts5_available() -> bool:
@@ -216,6 +220,15 @@ class EpisodeIndex:
             })
             if len(out) >= lim:
                 break
+        # RELATIVE FLOOR (counterweight to OR-breadth): keep only hits scoring within 15% of the top hit,
+        # always keeping #1. OR-join maximizes recall; this trims the long tail of turns that matched on a
+        # single weak/common term, so a precise query still returns a precise set (and a vague one degrades
+        # to "the few most relevant", not "30 loosely-related turns"). Degenerate scores (≤0) → keep all.
+        if out:
+            top = out[0]["score"]
+            if top > 0:
+                cut = top * 0.15
+                out = [out[0]] + [h for h in out[1:] if h["score"] >= cut]
         return out
 
     def close(self) -> None:

--- a/src/memagent/tui.py
+++ b/src/memagent/tui.py
@@ -169,10 +169,28 @@ def _render_tool_result(e):
     return Group(*body)
 
 
+# The RichSink whose spinner / streaming Live currently owns the terminal. A mid-turn console.input()
+# (ask_user, confirm) while a Live is active does NOT echo the user's keystrokes — the Live redraws over
+# the input line, so the typed answer is invisible. `_pause_active_live()` stops it first; the next event
+# restarts a fresh region. Single point so EVERY mid-turn Rich prompt is covered (no per-call-site fix).
+_ACTIVE_RICH_SINK = None
+
+
+def _pause_active_live() -> None:
+    s = _ACTIVE_RICH_SINK
+    if s is not None:
+        try:
+            s._stop()
+        except Exception:  # noqa: BLE001 — pausing the live UI must never break the prompt
+            pass
+
+
 class RichSink:
     """An event sink that renders the live turn with Rich. Drop-in for cli_sink."""
 
     def __init__(self, console: Console, stats: dict):
+        global _ACTIVE_RICH_SINK
+        _ACTIVE_RICH_SINK = self        # so ask_user/confirm can pause the live region before reading input
         self.c = console
         self.stats = stats
         self._status = None
@@ -625,6 +643,7 @@ def confirm(console: Console, name: str, detail: str, reason: str) -> str:
     console.print(Text.assemble(
         Text("  ⚠ allow ", style=TH["warn"]), Text(name, style=TH["tool"]),
         Text(f" {_shorten(detail, 60)!r}? ", style=TH["dim"]), Text(f"({reason})", style=TH["dim"])))
+    _pause_active_live()        # stop the turn spinner so the typed answer echoes
     try:
         ans = console.input("    [y]es / [n]o / [a]lways ▸ ").strip().lower()
     except (EOFError, KeyboardInterrupt):
@@ -640,6 +659,7 @@ def ask_user(console: Console, question: str, options=None) -> str:
         for i, o in enumerate(options, 1):
             console.print(Text(f"     {i}. {o}", style=TH["dim"]))
         console.print(Text("     (type a number, or your own answer)", style=TH["dim"]))
+    _pause_active_live()        # stop the turn spinner so the typed answer echoes
     try:
         ans = console.input("  your answer ▸ ").strip()
     except (EOFError, KeyboardInterrupt):

--- a/tests/test_ask_echo.py
+++ b/tests/test_ask_echo.py
@@ -1,0 +1,65 @@
+"""ask_user / confirm must PAUSE the live turn-spinner before reading input — otherwise the Rich Live
+region owns the terminal and the user's typed answer is not echoed (the 'my answer is invisible' bug).
+No model. Run: PYTHONPATH=src python tests/test_ask_echo.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+CHECKS = []
+def check(fn):
+    CHECKS.append(fn)
+    return fn
+
+
+class _FakeConsole:
+    """Stands in for the prompt console: records that input() was called, returns a fixed answer."""
+    def __init__(self, answer):
+        self.answer = answer
+        self.inputs = 0
+    def print(self, *a, **k):
+        pass
+    def input(self, *a, **k):
+        self.inputs += 1
+        return self.answer
+
+
+@check
+def ask_user_pauses_the_live_spinner_before_reading():
+    from rich.console import Console
+    from memagent import tui
+    sink = tui.RichSink(Console(), {})        # registers itself as the active live sink
+    sink._spin("working…")
+    assert sink._status is not None, "precondition: a turn spinner is live"
+    fc = _FakeConsole("blue")
+    ans = tui.ask_user(fc, "which color?")
+    assert ans == "blue" and fc.inputs == 1, "the answer must be read and returned"
+    assert sink._status is None, "the live spinner MUST be stopped before input (else no echo)"
+
+
+@check
+def confirm_pauses_the_live_spinner_before_reading():
+    from rich.console import Console
+    from memagent import tui
+    sink = tui.RichSink(Console(), {})
+    sink._spin("working…")
+    assert sink._status is not None
+    ans = tui.confirm(_FakeConsole("y"), "run_command", "rm -rf x", "danger")
+    assert ans == "yes"
+    assert sink._status is None, "confirm must stop the live spinner before reading input"
+
+
+def main():
+    failed = 0
+    for fn in CHECKS:
+        try:
+            fn(); print(f"PASS {fn.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1; print(f"FAIL {fn.__name__}: {e!r}")
+    print(f"\n{len(CHECKS) - failed}/{len(CHECKS)} passed")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -7,7 +7,7 @@ import tempfile
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from memagent.history import make_history_tool, render_index, render_trace  # noqa: E402
+from memagent.history import make_history_tool, render_full, render_index, render_trace  # noqa: E402
 from memagent.memory import NullMemory  # noqa: E402
 
 CHECKS = []
@@ -85,12 +85,28 @@ def tool_fetch_trace_and_specific_turn():
 
 
 @check
-def trace_is_bounded():
+def trace_has_no_read_cap_but_bounds_per_obs_at_the_seal():
+    # NO read-side total cap: every requested turn comes back (a cap dropped whole turns / cut conclusions).
+    # The bound is the SEAL — a legacy record's raw obs is tailed per-observation (OBS_TAIL), nothing dropped.
     lines = [{"task_id": "t", "turn": i, "ts": "2026-06-16T12:00:00",
               "record": _rec(f"turn{i}", "", [{"slice": "", "action": [{"name": "run", "args": {}, "failing": False}],
                                                "observation": ["x" * 5000]}])} for i in range(1, 20)]
-    out = render_trace(lines, cap=2000)
-    assert len(out) < 2600 and "truncated" in out                # capped regardless of N requested
+    out = render_trace(lines)
+    assert "turn 1" in out and "turn 19" in out and "truncated" not in out   # all turns, no total cap
+    assert "x" * 5000 not in out                                             # raw obs bounded per-obs at the seal
+
+
+@check
+def trace_and_full_return_the_full_conclusion_for_a_large_turn():
+    # the 'can't locate my second finding' read-side bug: a big turn's conclusion (markdown tail) must survive,
+    # and `full` must surface the note (the agent's reply lives there, NOT in the seed slice).
+    concl = "Finding 6: tab links drop string[] params."
+    big_md = "## seed\n" + ("filler " * 5000) + f"\n\n## conclusion\n{concl}"
+    line = {"task_id": "t", "turn": 7, "ts": "2026-06-16T12:00:00",
+            "record": {"title": "review page.tsx", "note": concl, "markdown": big_md,
+                       "steps": [{"slice": "seed-slice-body"}], "meta": {}}}
+    assert concl in render_trace([line]), "the conclusion at the markdown tail must survive (no read cap)"
+    assert concl in render_full([line]), "full mode must surface the note/conclusion, not just the seed slice"
 
 
 class _FakeMem:

--- a/tests/test_recall_search.py
+++ b/tests/test_recall_search.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from memagent.history import render_search                 # noqa: E402
 from memagent.pagetable import PageTable                   # noqa: E402
-from memagent.search_index import EpisodeIndex, fts5_available  # noqa: E402
+from memagent.search_index import EpisodeIndex, _fts_match_query, fts5_available  # noqa: E402
 
 CHECKS = []
 def check(fn):
@@ -103,6 +103,48 @@ def fts5_only_session_filter_is_real():
     assert {h["turn"] for h in only} == {7}, only          # within THIS session, by content
     excl = idx.search("postgres", exclude_session="S")
     assert all(h["session_id"] != "S" for h in excl) and excl, excl   # cross drops S, keeps OTHER
+    idx.close()
+
+
+# --- OR-join + relative floor (the 'can't locate my second finding' production bug) --------------
+@check
+def query_tokens_are_or_joined_not_and_joined():
+    # AND-join meant one absent token (the ordinal 'second') zeroed the whole result. OR is recall-correct.
+    assert _fts_match_query("a b c") == '"a" OR "b" OR "c"', _fts_match_query("a b c")
+    assert _fts_match_query("solo") == '"solo"'
+    assert _fts_match_query("") == ""
+
+
+@check
+def or_join_finds_the_review_despite_ordinal_meta_terms():
+    if not fts5_available():
+        print("  (skipped: no FTS5)"); return
+    idx = EpisodeIndex(":memory:")
+    idx.index_episode(session_id="S", task_id="t", turn=7, ts="", title="review page.tsx",
+        note="Finding 2: invalid query-string archetype/coding values are blindly cast in page.tsx.",
+        text="app/page.tsx casts arrayParam to RoleArchetype; archetypeCounts missing bd finance strategy.")
+    idx.index_episode(session_id="S", task_id="t", turn=8, ts="", title="unrelated",
+        note="we discussed the deployment pipeline and CI config.", text="ci yaml deploy kube")
+    # 'second'/'your'/'is' are NOT in the review text → AND-join returned nothing (the bug); OR-join finds it
+    hits = idx.search("what is your second finding for page.tsx", only_session="S")
+    turns = [h["turn"] for h in hits]
+    assert 7 in turns and hits[0]["turn"] == 7, f"OR-join must surface + rank the review turn; got {turns}"
+    idx.close()
+
+
+@check
+def relative_floor_trims_the_weak_single_term_tail():
+    if not fts5_available():
+        print("  (skipped: no FTS5)"); return
+    idx = EpisodeIndex(":memory:")
+    idx.index_episode(session_id="S", task_id="t", turn=1, ts="", title="strong",
+                      note="alpha beta gamma delta page", text="alpha beta gamma delta page")
+    for i in range(2, 6):
+        idx.index_episode(session_id="S", task_id="t", turn=i, ts="", title=f"weak{i}",
+                          note="page", text="page sidebar layout grid")
+    hits = idx.search("alpha beta gamma delta page", only_session="S")
+    assert hits and hits[0]["turn"] == 1, "the strong multi-term match must rank first"
+    assert len(hits) < 5, f"the relative floor should trim the weak single-term tail; kept {len(hits)}"
     idx.close()
 
 


### PR DESCRIPTION
Three production bugs found using memagent on the hunter repo (commit fe1fcd2):

1. **Recall search found nothing** — `_fts_match_query` AND-joined query tokens, so one absent token (the ordinal "second") zeroed the result. → OR-join + relative floor (0.15×top, always-keep-#1). Verified on the live vault.
2. **Found turns returned no content** — read-side `TRACE_MAX`/`FULL_MAX` caps truncated the markdown, and the distilled conclusion is appended last (so it was cut first); `render_full` rendered only the seed slice. → Remove the read caps (fetch returns in full) + append the conclusion in `render_full`. The bound stays at the seal (save-side excerpt) + transience + overflow. Verified: the real review turn now returns all 6 findings (compact + full).
3. **Mid-turn `ask_user`/`confirm` input was invisible** — the Rich Live spinner owned the terminal during `console.input()`. → `_pause_active_live()` before any mid-turn prompt.

Tests: +`test_ask_echo`; OR-join/floor + read-cap/conclusion regression guards. Offline suite **102 green**. `evals/` intentionally uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)