### PR TITLE
Cap audit fixes: remove within-loop content cuts (page/breadth/raise)

### DIFF
--- a/src/memagent/code_index.py
+++ b/src/memagent/code_index.py
@@ -196,12 +196,14 @@ class RipgrepCodeIndex:
             return set()
 
     # --- structural map: rank by personalized PageRank over the def/ref graph ---
-    def graph_map(self, query: str, max_files: int = 400, max_chars: int = 4000) -> str:
+    def graph_map(self, query: str, max_files: int = 400, max_shown: int = 20) -> str:
         """Repo map ranked by PERSONALIZED PAGERANK over the symbol def/ref graph, seeded on the
         files that match the query lexically. Rank flows along call/import edges, so a relevant file
         surfaces even with ZERO query-word overlap when a matched file references it — exactly the
         neutral-vocabulary target a purely-lexical ranking truncates on a large repo. Degrades to
-        lexical order when there is no graph signal. Bounded by max_chars, like every tier.
+        lexical order when there is no graph signal. Bounded by BREADTH — the top `max_shown` ranked
+        files, each shown COMPLETE — NOT a char cut (a char cut dropped lower-ranked files mid-list,
+        the 'where is function X?' miss, and could render a file half-shown; breadth is deterministic).
 
         The query-INDEPENDENT graph (defs/edges/skeletons) is cached on this instance and rebuilt
         only when the tree changes (see _graph), so per-turn cost is just lexical search + PageRank,
@@ -220,18 +222,15 @@ class RipgrepCodeIndex:
         # rank: structural score, then lexical strength, then path (deterministic ties)
         files.sort(key=lambda rel: (pr.get(rel, 0.0), len(matched.get(rel, ()))), reverse=True)
         blocks: list[str] = []
-        used = 0
         for rel in files:
             dlines = g["skeleton"].get(rel)
             if not dlines:
                 continue
             hit = matched.get(rel)
             head = rel + (f"   (matches: {', '.join(sorted(hit))})" if hit else "")
-            block = head + "\n" + "\n".join("  " + d for d in dlines)
-            if used + len(block) + 1 > max_chars:
+            blocks.append(head + "\n" + "\n".join("  " + d for d in dlines))
+            if len(blocks) >= max_shown:        # BREADTH bound: top-N ranked files, each shown COMPLETE
                 break
-            blocks.append(block)
-            used += len(block) + 1
         return "\n".join(blocks)
 
     def _graph(self, max_files: int) -> dict:

--- a/src/memagent/mining.py
+++ b/src/memagent/mining.py
@@ -146,7 +146,7 @@ class LessonMiner:
             "No preamble, no markdown."
         )
         user = (
-            f"Task: {task}\nError that was hit and then resolved:\n{one_line(pitfall, 400)}\n"
+            f"Task: {task}\nError that was hit and then resolved:\n{one_line(pitfall, 2000)}\n"
             f"Files changed: {', '.join(files) or '(unknown)'}\nWrite the lesson:"
         )
         try:

--- a/src/memagent/pagetable.py
+++ b/src/memagent/pagetable.py
@@ -26,9 +26,9 @@ import os
 from .interfaces import PageRef
 from .text_utils import format_ts, normalize_ws
 
-# Per-code-map preview cap (signatures are compact; bounded like every tier). Mirrors the
-# former slice.DISCOVERY_CHARS so the rendered RELATED CODE block is byte-identical.
-CODE_PREVIEW_CHARS = 4000
+# Per-code-map preview cap — a generous PHYSICAL backstop only. The real bound is BREADTH, applied ONCE
+# in graph_map (top-N ranked files, each shown complete). This must not re-cut the breadth-bounded map.
+CODE_PREVIEW_CHARS = 12000
 
 
 class PageTable:

--- a/src/memagent/regions.py
+++ b/src/memagent/regions.py
@@ -24,13 +24,13 @@ MANIFEST_TURNS = 8       # PAGED-OUT HISTORY manifest window — bounded locator
 # size regardless of session length; content is paged in on demand, never accumulated into the slice).
 MAX_OPEN_THREADS = 6  # OTHER OPEN THREADS tier cap — bounded presentation of parked topics
 MAX_FINDINGS = 8         # bounded ring of distilled conclusions (anti-re-derivation; not a transcript)
-MAX_FINDING_CHARS = 200  # each finding is ONE compact line — distilled, never narration
+MAX_FINDING_CHARS = 300  # each finding is ONE compact line — distilled, never narration (causal tail matters)
 MAX_REQUIREMENTS = 20    # bounded STANDING REQUIREMENTS contract (count) — the moat's no-unbounded-growth
-MAX_REQ_CHARS = 200      # each requirement is ONE compact line
+MAX_REQ_CHARS = 300      # each requirement is ONE compact line (contracts — a long signature must survive)
 MAX_PLAN_ITEMS = 20      # bounded PLAN (TodoWrite) — same no-unbounded-growth rule as requirements
-MAX_PLAN_CHARS = 200     # each plan step is ONE compact line
+MAX_PLAN_CHARS = 300     # each plan step is ONE compact line (multi-file scope must survive)
 _PLAN_MARK = {"done": "x", "in_progress": "~", "pending": " "}
-MAX_MISSION_CHARS = 300  # the MISSION (session north-star) is ONE compact objective line
+MAX_MISSION_CHARS = 500  # the MISSION (session north-star) is ONE compact objective line (don't clip scope)
 
 MAX_REPORT_CHARS = 280   # OPEN USER REPORT — one compact verbatim line (bounded; never a transcript)
 MAX_ACTION_LOG = 24      # bounded anti-loop tally (no-transcript: the action_log can't grow per-topic forever)
@@ -44,7 +44,8 @@ FULL_FILE_LINES = 1200
 REGION_LINES = 400
 DISCOVERY_K = 6
 MAX_CONVERSATION = 4     # RECENT CONVERSATION ring — last N user<->assistant exchanges (short-range continuity)
-CONVO_MSG_CHARS = 300    # per-message cap in the conversation tier (bounded; the cache holds the full text)
+CONVO_MSG_CHARS = 800    # per-message GIST cap in the conversation tier (count-bounded by MAX_CONVERSATION;
+# the cache holds the full text and recall pages it back, so this is a display-gist size, not the only copy)
 
 
 # ── PER-REGION RENDER: UNCAPPED-BY-RELEVANCE ──────────────────────────────────
@@ -329,7 +330,7 @@ def record_action(s, name: str, args: dict, out: str, failing: bool | None = Non
     if failing is None:
         failing = out.startswith("Error") or out.startswith("Exit code")
     if failing:
-        s.last_error = out if len(out) <= 800 else out[:120] + "\n…[trace truncated]…\n" + out[-680:]
+        s.last_error = out if len(out) <= 3000 else out[:2000] + "\n…[trace truncated]…\n" + out[-900:]
     elif name in ("run_command", "execute_code"):
         s.last_error = ""  # a successful run/script clears the error (both are execution — general)
     sig = action_sig(name, args)

--- a/src/memagent/swap.py
+++ b/src/memagent/swap.py
@@ -27,7 +27,8 @@ DEP_CEILING = 64   # per-symbol caller fan-out backstop — keep ALL direct call
                    # (caller-first ranked in code_index.deps); generous physical guard, not a relevance cap.
 MAX_GHOSTS = 6     # GHOST INDEX ring — pointers to recently paged-out files/skills (also the refault recency window)
 MAX_ACTIVE_SKILLS = 2    # keep only the most-recently-loaded skills active
-MAX_SKILL_CHARS = 4000   # a loaded skill body is capped before it enters the slice
+MAX_SKILL_CHARS = 12000  # a loaded skill body before it enters the slice; bounded by COUNT (MAX_ACTIVE_SKILLS=2),
+# so this is generous — a half-read skill (helpers/examples/patterns in the tail lost) misleads more than it costs
 MAX_REVIEWED = 8         # bounded ring of history lookbacks done (the recall_history ratchet)
 HOT_TTL = 3              # steps a REFAULT-promoted file stays kernel-protected (self-tuning; not the model)
 HOT_CEILING = 4  # bound the kernel-granted soft-pin set — never an accumulating tier (decoupled from

--- a/src/memagent/tools.py
+++ b/src/memagent/tools.py
@@ -916,8 +916,9 @@ class LocalToolHost:
         diff = p.stdout
         if not diff.strip():
             return f"No changes vs {ref} — the working tree matches it. Nothing to review."
-        cap = 20000
-        body = diff if len(diff) <= cap else diff[:cap] + f"\n… (diff truncated at {cap} of {len(diff)} chars)"
+        # PAGE a large diff out (full diff preserved on disk, reachable via read_file) instead of a hard
+        # truncation that silently discarded the tail — a review/security task must not miss bugs past the cut.
+        body = self._page_out(diff, label=f"git-diff-{ref}")
         return (f"git diff {ref} ({len(diff)} chars). Review for correctness, security, and edge cases; "
                 f"cite file:line per issue.\n\n{body}")
 

--- a/tests/test_code_index.py
+++ b/tests/test_code_index.py
@@ -72,8 +72,9 @@ def map_is_bounded():
     if _skip_no_rg():
         print("  (skip: no rg)"); return
     idx = RipgrepCodeIndex(root=_repo())
-    m = idx.graph_map("checkout", max_chars=120)
-    assert len(m) <= 130            # honored the cap (small slack for the final block boundary)
+    m = idx.graph_map("checkout", max_shown=1)
+    heads = [ln for ln in m.splitlines() if ln and not ln.startswith("  ")]   # file heads (skeleton lines indent)
+    assert len(heads) <= 1, f"breadth bound: at most max_shown files shown complete, got {len(heads)}"
 
 
 @check
@@ -121,10 +122,11 @@ def graph_surfaces_neutral_callee_that_lexical_truncates():
         print("  (skip: no rg)"); return
     idx = RipgrepCodeIndex(root=_graph_repo())
     q = "checkout discount member"
-    # tight budget: the neutral bug file has ZERO query overlap and sorts after 40 filler files,
-    # so a purely-lexical ranking would truncate it — but PageRank flows rank cart->billing and keeps it.
-    graph = idx.graph_map(q, max_chars=400)
-    assert "svc/billing.py" in graph, "PageRank should surface the called neutral file"
+    # tight breadth: the neutral bug file has ZERO query overlap and sorts after 40 filler files,
+    # so a purely-lexical ranking would drop it below the top-N — but PageRank flows rank cart->billing,
+    # so it ranks high enough to make the top-N breadth window.
+    graph = idx.graph_map(q, max_shown=6)
+    assert "svc/billing.py" in graph, "PageRank should surface the called neutral file within the top-N"
     # and it ranks ABOVE the filler (appears before any aaa_filler line)
     assert graph.index("svc/billing.py") < graph.index("aaa_filler/")
 
@@ -134,7 +136,9 @@ def graph_map_is_bounded():
     if _skip_no_rg():
         print("  (skip: no rg)"); return
     idx = RipgrepCodeIndex(root=_graph_repo())
-    assert len(idx.graph_map("checkout", max_chars=200)) <= 230
+    m = idx.graph_map("checkout", max_shown=3)
+    heads = [ln for ln in m.splitlines() if ln and not ln.startswith("  ")]
+    assert len(heads) <= 3, f"breadth bound honored regardless of repo size; got {len(heads)} files"
 
 
 @check


### PR DESCRIPTION
Project-wide cap audit follow-up. Removes the within-loop content cuts that handed the model partial info (same class as the recently-fixed recall caps).

**Rule:** bound by COUNT at the seal, never by char-length at read/render; page (durable blob + `read_file`) if an item is too big.

- **git diff** 20k truncate → `_page_out` (only cap losing data; degraded review/security)
- **graph_map** char-cut → top-N-files breadth (deterministic, complete files); `CODE_PREVIEW_CHARS`→12k backstop
- **CONVO_MSG_CHARS** 300→800; **MAX_FINDING/REQ/PLAN_CHARS** →300, **MISSION**→500; **last_error** keep-whole→3000; **MAX_SKILL_CHARS** 4k→12k; **mining** distill 400→2000

Kept: count/seal/breadth/physical bounds, `OBS_TAIL` (legacy), `_RG_MAX_COLUMNS`. Offline suite **102 green**. `evals/` uncommitted. Note: graph_map ~2× the RELATED CODE tier (max_shown=20, tunable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)