### PR TITLE
memem: cache-only distill + /learn skill authoring + paths/cluster borrows

### DIFF
--- a/docs/MEMEM-DIAGNOSIS.md
+++ b/docs/MEMEM-DIAGNOSIS.md
@@ -1,0 +1,196 @@
+# memem (L3) Layer — Diagnosis & Action Plan
+
+Scope: memagent's cross-session memory layer — (1) distill→memem, (2) retrieve→slice, (3) the missing transcript→skill. Compared against EverOS (engine), EverMe/evermem-claude-code (plugin), and Hermes `/learn`. Generated 2026-06-25 from a 5-reader workflow + a supplemental EverMe study; every claim verified against source.
+
+## 1. Diagnosis
+
+### Distill (memories → memem) — VERDICT: **HEALTHY** (one real stub, one real security gap, rest are honest design limits)
+
+**Evidence (verified against source):**
+- Two-write design is sound: a LIVE per-turn miner (`mining.py:84-122` `LessonMiner._on_turn_end`) plus a session-end batch sweep (`memory.py:463-490` `consolidate`). Both go through the same `Memory.remember()` seam → memem stays behind the interface (moat: llm-agnostic ✓).
+- The corrective gate is genuinely 4-fold, not 3 — the input under-described it. `mining.py:90-101`: `stop_reason=="end_turn"` **and** `self._errors` present **and** `not s.last_error` (turn ended clean) **and** `s.edited_files` (a real fix was made) **and** key not in `_saved`. The `edited_files` requirement is the load-bearing gate that prevents mining "Lesson: <user's query>" from no-op turns. This is correct and well-reasoned.
+- `is_self_inflicted()` (`mining.py:35-41`) filters host-guardrail errors so confinement/permission hits teach nothing — task-agnostic substring match. Good.
+- Title is the **pitfall signature, never the goal** (`mining.py:121`, `pitfall_signature` strips the `Error:` prefix at `mining.py:50-54`) — recall matches on the engineering failure, not user phrasing. This is a deliberate, correct fix.
+- `make_miner()` returns `None` for `NullMemory` (`mining.py:174-179`) → graceful degrade ✓.
+- `promote_episodes`/`promote_procedures` (`consolidate.py:62-98`, `114-150`) are **pure** (no I/O, no LLM), dedupe by signature/shape, frequency-weight via `Counter`, cap procedures at 3. Clean and testable.
+- Provenance is stamped on auto skills (`consolidate.py` render via `skill_provenance.frontmatter_line(AUTO)`) → curator can prune only auto skills ✓.
+
+**Gaps/bugs (verified):**
+
+1. **REAL — secret can leak into the LLM distill prompt** (`mining.py:138-161`). `_distill()` sends `task` + `pitfall` to `self.llm.complete()`. Threat-scan/redact happens only in `remember()` (`memory.py:304-309`), i.e. **after** distill. An API key in an error message reaches the LLM in plaintext. The deterministic consolidate path scans `_is_secret` *before* building (`consolidate.py:74`), but the LLM mining path does not. **This is the one fix-now security item in distill.**
+
+2. **REAL but a known stub — `render_skill()` is deterministic-only** (`consolidate.py:153-168`). The module docstring and the function docstring both say "the LLM-distill upgrade (generalizing the steps) slots in here" but `render_skill(proc)` takes only a dict, no `llm` param, no mode flag. Skills are *recorded* procedures, not *generalized* ones. Verified: no LLM call anywhere in the function.
+
+3. **MINOR — misleading wording.** `render_skill` emits "Auto-distilled from N run(s)" (`consolidate.py` body) while the docstring elsewhere correctly calls it "a RECORDED procedure." Use "Observed from N run(s)" until LLM generalization actually lands.
+
+4. **DESIGN LIMIT (not a bug) — `MAX_PROCEDURES=3` silent cap** (`consolidate.py:24,148`). Top-3-by-freq promoted, rest dropped silently. Correct spam guard; add a debug log only.
+
+5. **DESIGN LIMIT — in-session dedup only.** `_saved` (`mining.py:72`) is session-local; cross-session dedup falls to memem's `memory_save` token_set_ratio (`operations.py:19-68`: ≥0.92 reject, 0.70–0.92 Haiku-merge). This is the correct division of labor (BORROW-periphery: memem owns dedup), but it is a *silent* reliance.
+
+6. **CORRECTION to the input:** the input claims `is_self_inflicted` could misclassify and *lose* data with no log. True there's no log, but this is intentional filtering of host errors, low severity — not data loss of real lessons.
+
+### Retrieve (memem → slice) — VERDICT: **HEALTHY**
+
+**Evidence (verified):**
+- Single read seam: `slice.py:891-893` calls `pages.lookup(goal, kind="memory-lessons", k=6)` once per build, cached by goal (`recall_cache[goal]`). One memem call per topic, not per turn ✓.
+- `recall()` (`memory.py:283-302`) order is correct: `retrieve(query, k=k, writeback=False, scope_id=self._scope)` → relevance-gate via `_memory_relevant` → `mark_used()` **only on surfaced hits** → return `Snippet[]`. Reinforcement tracks what the agent actually sees, not raw top-k. This is the right feedback discipline.
+- `_memory_relevant()` (`memory.py:45-53`) is a whole-word discriminating-term gate (`\bterm\b`, lowercased), tolerant when no terms extracted. Task-agnostic, portable. Turns memem's blind top-k into relevant-or-nothing.
+- `render_memory()` (`slice.py:655-661`) wraps every lesson in `wrap_untrusted(kind="memory")` each turn (re-applied, not persisted); suppresses empty tier. Untrusted fencing is correct.
+- Tier is STABLE, reconstructed once per build from live recall — bound-is-relevance, no within-loop size cut ✓.
+
+**Gaps/bugs (verified):**
+
+1. **MINOR (correct-by-design) — empty-terms keeps all hits** (`memory.py:50-51`). When the query yields no discriminating terms, the gate returns `True` for everything, so memem's k=6 is the only filter. Low practical risk (memem already disambiguates), but it does relax "relevant-or-nothing" on un-discriminating goals.
+
+2. **UNDER-USE, not bug — no score floor.** `_memory_relevant` is a term gate with no confidence floor; relies entirely on memem's RRF ranking + k=6. Acceptable (memem owns scoring).
+
+3. **The input's "scope param mismatch BUG" is NOT a bug — confirmed.** `memory.py:313` passes `scope_id=scope` correctly; the adapter renames `scope`→`scope_id` at the call site. Working as intended.
+
+### memem backend fit — adapter uses memem correctly; several capabilities under-used
+
+The adapter is faithful: it talks only to `retrieve`, `memory_save`, `bump_access` and lets memem own embeddings, BM25, FTS5, RRF fusion, 3-phase decay, and dedup (BORROW-periphery ✓). Under-used memem capabilities (all confirmed against the input's retrieve.py line refs):
+
+- **`paths_context`** (retrieve.py:712-716) — never populated. The slice knows `s.active_files`; passing them would give a 1.05× bonus to memories tagged with the files being edited. Cheap, moat-safe.
+- **`writeback=True`** (retrieve.py:950-960) — adapter passes `writeback=False` and manually loops `mark_used()`. Not wrong, but the manual loop reinforces *every kept hit*, which is actually *better* than blind writeback (reinforces only surfaced). Keep the manual loop; this is a deliberate, correct divergence, not a defect.
+- **`should_demote` / explicit layer management** (decay.py:123-141) — never called. memagent trusts memem's ranking decay and never demotes. Fine for now (no curator yet).
+- **Cross-vault episode pooling** (search_index.py) — memagent searches only its own vault. By design (vault decoupled); not a gap to fix.
+
+**Capability comparison table:**
+
+| Capability | memagent today | EverOS | Gap |
+|---|---|---|---|
+| Distill trigger | Per-turn LIVE miner + session-end deterministic sweep | Sync pipeline + async OME strategies on event bus | memagent has no **user-initiated** distill (no `/learn`) |
+| Fact extraction | Deterministic corrective-pitfall, optional 1-shot LLM | LLM atomic-fact extraction always on | memagent LLM path is optional + has a secret-leak gap |
+| Procedure→skill | `promote_procedures`→`render_skill` (RECORDED, no LLM) | `extract_agent_skill` with cosine clustering + LLM | No **generalization**; no clustering of similar procedures |
+| Skill ranking | freq-weight + `skill_usage` sidecar (`bump_use` on load, skills.py:153) | cosine top-K, MAX_SKILLS_IN_PROMPT=10 | memagent caps via MAX_ACTIVE_SKILLS; no usage→memem decay |
+| Consolidation merge | dedup by sig/shape, no cluster merge | EpisodeReflector LLM merge, deprecation links | No cluster-aware merge / deprecation chain |
+| Retrieval ranking | memem 3-way RRF + term gate (delegated) | 4-layer hierarchical, MaxSim child rerank, LR eviction | No L2 MaxSim fact-rerank (delegated to memem; acceptable) |
+| Live re-index | episodic JSONL + FTS5 mirror on write | cascade daemon watches markdown, sha256 re-embed | memem owns vault re-index; memagent episodic is append-only (fine) |
+
+## 2. What to borrow from EverOS — moat-safe only
+
+1. **Cluster-before-promote for procedures.** EverOS `extract_agent_skill` clusters episodes by `task_intent` cosine before writing a skill. **Change:** in `promote_procedures` (`consolidate.py:114-150`), before the action-shape dedup, optionally group candidates whose `goal` embeddings (via memem's embedder — borrow, don't reinvent) are close, and promote the cluster centroid. Keep it pure by accepting an injected similarity fn so the function stays LLM-agnostic and testable. Effort M. Moat-safe: still deterministic structure, memem owns embeddings.
+
+2. **Deprecation links instead of silent overwrite.** EverOS marks superseded memories `deprecated_by` rather than deleting. **Change:** when consolidate re-promotes a fact whose sig already exists, pass a `related`/`supersedes` field through `remember()`→`memory_save` so memem's link signal (retrieve.py link bonus) reflects the chain. Effort S. Moat-safe (just frontmatter).
+
+3. **Make consolidation strategies configurable (hot-enable).** EverOS gates reflection behind `ome.toml`. memagent's `consolidate()` always runs both promoters. **Change:** add `cfg` flags `promote_facts` / `promote_procedures` / cap overrides (mirrors the existing `cfg.mine = deterministic|llm|off`). Effort S. Moat-safe.
+
+4. **DO NOT borrow** EverOS's always-on LLM reflection or its 4-layer hierarchical retriever. That would duplicate what memem already owns (RRF, decay) and violate BORROW-periphery. memagent's delegation to memem is the correct posture.
+
+## 3. The missing function — transcript → reusable SKILL (Hermes `/learn`)
+
+**Reconciliation (the key question):** memagent's `consolidate.py` "routes procedures → skills" is **real and working** (`memory.py:476-488` writes `~/.memagent/skills/{name}/SKILL.md`), but it is **automatic, deterministic, session-end, and RECORDED-only**. There is genuinely **no foreground user-initiated path** — confirmed by `grep` (no `learn` tool in `cli.py`/`tools.py`) and by `skill_provenance.py:5` which states verbatim: *"memagent has no foreground tool that writes skills today — consolidate.render_skill is the ONLY writer."* So Hermes `/learn` is a **genuine missing function**, not a duplicate.
+
+**Decision: EXTEND, don't replace.** Keep `consolidate` as the background auto-path. Add a foreground `/learn` that reuses the *same* storage (`skills_dir` + `render_skill` schema + the SKILLS tier) but differs on three axes: trigger (user), distillation (LLM generalization, the very upgrade `render_skill` was stubbed for), and provenance (`USER`, never auto-pruned — the `set_authoring_origin` ContextVar at `skill_provenance.py` already exists for exactly this).
+
+**Concrete design:**
+
+- **Trigger:** a foreground `learn` tool (model-callable) + a `/learn` CLI command, following Hermes (`learn_prompt.py`): open-ended, sources = current session transcript / a path / pasted notes. Default source when empty = "the workflow we just went through" → read from the **episodic cache** (`read_episodes(session_id)`), NOT the slice (preserve the no-transcript invariant — the episodic cache is the lossless replay store, `memory.py:4`).
+- **Distill prompt:** borrow Hermes' embedded `_AUTHORING_STANDARDS` (house-style frontmatter + When-to-Use / Process / Pitfalls / Verification sections). This is finally the implementation of the `render_skill` LLM upgrade — add an `llm`-bearing variant `render_skill_llm(proc, llm)` as a **separate pure-ish function** (keep deterministic `render_skill` intact), so the moat seam is unchanged. Prompt instruction: "generalize the recorded steps into reusable prose; phrase as declarative process, not session-specific narration."
+- **Skill schema:** identical to `render_skill` output (name/description frontmatter + body) so the existing `SkillManager.discover()` (`skills.py:95-126`) parses it unchanged. Set `provenance: user` via `set_authoring_origin(USER)`.
+- **Storage:** existing `~/.memagent/skills/{name}/SKILL.md`. Recall/reuse: existing SKILLS tier (`render_skills`, `MAX_ACTIVE_SKILLS`, loaded on `skill()` call into ACTIVE SKILL tier). No new tier needed.
+- **Dedup/quality gate:** borrow Hermes' frontmatter-first validation + name-collision check + atomic-write-then-security-scan-with-rollback (`skill_manager_tool.py:291-327`, `579-585`). memagent already has `scan_for_threats(scope="strict")` on skill write (`memory.py:481`) — wire it into the `/learn` path identically.
+- **Moat-fit:** ✓ task-agnostic (no skill-type heuristics), ✓ llm-agnostic (LLM only inside the new render fn, behind the same `Memory`/llm seam, deterministic `render_skill` remains the fallback when no llm), ✓ no-transcript (reads episodic cache, not slice), ✓ BORROW (Hermes authoring standards + memem storage, nothing reinvented).
+- **Secret handling:** run `scan_for_threats` on the source material **before** sending to the distill LLM (same fix as distill-bug #1) — `/learn` reads a transcript that may contain secrets.
+
+## 4. Prioritized ACTION PLAN
+
+### FIX-NOW (real bugs in §1)
+
+**F1 — Threat-scan before LLM distill (security).**
+- What: in `mining.py:_distill`, call `scan_for_threats`/skip if `_is_secret(pitfall or task)` **before** `self.llm.complete()`. Mirror `consolidate.py:74`.
+- Files: `mining.py:138-161` (+ import from `safety`).
+- Effort: S. Risk: low (only blocks tainted episodes from the LLM; deterministic path still mines).
+- Verify: unit test — episode with `API_KEY=sk-...` in pitfall, `mode="llm"`, assert `llm.complete` not called and either deterministic fallback or no-mine.
+
+**F2 — Fix misleading "Auto-distilled" wording.**
+- What: change `render_skill` provenance line to "Observed from N run(s)" until F-BUILD-B lands.
+- Files: `consolidate.py` (the `prov = ...` line).
+- Effort: S. Risk: none. Verify: existing render_skill test asserts new string.
+
+**F3 — Log the silent procedure cap.**
+- What: when `len(cand) > cap` in `promote_procedures`, emit a debug log of how many were dropped.
+- Files: `consolidate.py:148-150`. Effort: S. Risk: none. Verify: test with 5 distinct smooth workflows asserts cap=3 + log emitted.
+
+### BUILD (the `/learn` function — §3)
+
+**B1 — `render_skill_llm(proc, llm)` (the stubbed upgrade).**
+- What: separate pure function that LLM-generalizes recorded steps into Hermes-standard sections; falls back to deterministic `render_skill` on llm failure/absence.
+- Files: new fn in `consolidate.py`; embed Hermes `_AUTHORING_STANDARDS`.
+- Effort: M. Risk: med (LLM output quality) — gate behind validation + provenance. Verify: golden-output test with a stub llm; assert frontmatter parses via `SkillManager._load`.
+
+**B2 — `learn` foreground tool + `/learn` CLI command.**
+- What: read default source from `read_episodes(session_id)`; **scan_for_threats first**; call `render_skill_llm`; write via the existing skills-dir path with `set_authoring_origin(USER)`; frontmatter+collision validation; atomic-write-then-scan-then-rollback.
+- Files: `tools.py` (register tool), `cli.py` (command), reuse `memory.py` write path, `skill_provenance.py`.
+- Effort: M. Risk: med. Verify: integration test — run a 4-step session, call `/learn`, assert a USER-provenance SKILL.md exists and `SkillManager.discover()` catalogs it; assert a transcript with a secret is redacted/blocked before the LLM.
+
+### BORROW (EverOS adoptions — §2)
+
+**R1 — `paths_context` into recall.** Pass `s.active_files` to `retrieve(paths_context=...)` in `memory.py:recall`. Effort S. Risk low. Verify: assert retrieve called with non-empty paths_context when slice has active files; recall_cache T2 test still green.
+
+**R2 — Configurable consolidation flags.** Add `cfg.promote_facts/promote_procedures/caps`. Files `config.py`, `consolidate.py`, `memory.py:consolidate`. Effort S. Risk low. Verify: flag off → no facts written.
+
+**R3 — Cluster-before-promote (optional similarity fn).** Inject an embedder into `promote_procedures` to group near-duplicate goals before shape-dedup. Files `consolidate.py`, wiring in `memory.py`. Effort M. Risk med (keep pure via injection). Verify: two semantically-equal-but-different-shape workflows collapse to one skill.
+
+**R4 — Deprecation/supersedes link on re-promoted facts.** Thread a `supersedes` field through `remember`→`memory_save`. Effort S. Risk low. Verify: re-promoting a known sig sets the link frontmatter.
+
+---
+
+**Honest bottom line:** Distill and Retrieve are genuinely **healthy** — the corrective gate, pitfall-titling, pure promoters, term-gate, untrusted fencing, and memem delegation are all correct and moat-compliant. There are exactly **two real defects worth fixing now** (F1 the secret-leak-into-LLM, F2 the wording), one **honest stub** (`render_skill` never got its LLM upgrade), and one **genuinely missing feature** (foreground `/learn`). Everything else is correct-by-design delegation to memem or deliberate divergence — do not invent work there.
+
+Files of record: `/Users/tongtao/Desktop/memagent/src/memagent/mining.py`, `/Users/tongtao/Desktop/memagent/src/memagent/consolidate.py`, `/Users/tongtao/Desktop/memagent/src/memagent/memory.py`, `/Users/tongtao/Desktop/memagent/src/memagent/slice.py`, `/Users/tongtao/Desktop/memagent/src/memagent/skills.py`, `/Users/tongtao/Desktop/memagent/src/memagent/skill_provenance.py`, `/Users/tongtao/Desktop/memagent/src/memagent/skill_usage.py`.
+
+---
+
+## Addendum — EverMe / evermem-claude-code (the product/plugin layer)
+
+Both EverMind Claude-Code plugins are **thin cloud clients**: rule-based hooks ship raw turns to the EverMem/EverOS *backend*, which does the distillation.
+- **Distill:** Stop/SessionEnd hooks parse the transcript (rule-based, NO client LLM) and POST raw turn-pairs to the cloud (`evermem` → `/api/v1/memories`; `EverMe` → `/mem/agent-memory` with `flush:true`). Backend extracts episodes/profiles.
+- **Retrieve:** UserPromptSubmit hook auto-injects (push) + MCP tools (`everme_search`/`everme_context`) for pull + a **queryless SessionStart context snapshot** (server-rendered profile). EverMe renders **multi-section results** (episodic / profile / skills / cases).
+- **Transcript→skill:** NEITHER plugin does it client-side — delegated to EverOS "Reflection", not exposed. **Confirms Hermes `/learn` is the template for #3.**
+
+Net vs memagent: memagent's local, LLM-distilled **named taxonomy** (facts/decisions/procedures) in transparent markdown is *richer* than "ship raw, let the cloud guess."
+
+**Borrowable from EverMe (moat-safe, additive to the EverOS borrows):**
+- **B-EM1 — multi-section RELEVANT MEMORY rendering:** split the recalled tier by kind (lessons vs decisions vs skills) so the model distinguishes "what you learned" from "what you decided." memagent flattens to one list (`render_memory`). Effort S.
+- **B-EM2 — queryless topic-start memory snapshot:** on a new topic, surface a no-query "recent + most-reinforced" snapshot, not only keyword recall. Effort S–M.
+- **NOT borrowable:** the cloud backend / cross-device sync — memagent is local + single-machine by design.
+
+---
+
+## IMPLEMENTED (2026-06-25) — the FIX-THE-PATH + plan execution
+
+The layering invariant is now enforced: **L1 slice ─seal→ L2 cache ─distill→ L3 memem ─recall→ L1 slice**, with distill sourcing *only* the cache and recall feeding *only* the slice.
+
+**FIX-THE-PATH (the layering violation).** Removed the per-turn `LessonMiner` that read the live slice. `mining.py` is now helpers-only (`is_self_inflicted`, `pitfall_signature`); all distillation is cache-only via `memory.consolidate → consolidate.promote_episodes / promote_procedures` (read `read_episodes`, never the slice). `promote_episodes` absorbed the miner's self-inflicted filtering — it now collects all failing observations and titles the lesson by the **last non-self-inflicted** one, so a self-inflicted-only episode mines nothing while a real error after a self-inflicted one still mines.
+
+**FIX-NOW.**
+- **F1 (security):** `render_skill_llm` scans the recorded material (`_is_secret` + `scan_for_threats` strict) **before** the LLM call and falls back to the deterministic render on any secret/threat/no-llm/failure — no secret ever reaches a distill LLM. (The cache is already redacted on archive; `write_skill_file` scans strict + redacts + writes atomically.)
+- **F2 (wording):** prov line is now "Observed from N successful run(s) this session." (was "Auto-distilled").
+- **F3 (cap):** `promote_procedures` logs the dropped-at-cap count instead of dropping silently.
+
+**BUILD (#3 — transcript → reusable skill).**
+- **B1 — `render_skill_llm`:** the stubbed generalization is real — deterministic frontmatter + LLM-generalized body, scan-first, degrades to recorded steps without an LLM.
+- **B2 — `/learn` + `write_skill`:** Hermes pattern — `build_learn_prompt` instructs the live agent to read THIS session from the **cache** (`recall_history`) and author a SKILL via the new foreground `write_skill` tool. The tool owns provenance (`provenance: user` — never auto-pruned) and the guarded write (validate frontmatter + scan strict + redact + atomic), so a model cannot forge AUTO provenance or smuggle an unscanned skill onto disk. `/learn` is routed in the CLI as a real turn. **Live-validated end-to-end (DeepSeek): the agent read the cache and wrote a `provenance: user` skill.**
+
+**BORROW.**
+- **R1 — file-context (`paths`):** lessons are tagged with their files on write (`remember → memory_save(paths=...)`); recall passes the files-in-play at topic-start to `retrieve(paths_context=...)`. Snapshotted at first recall and cached by goal, so it preserves the one-memem-call-per-topic property (per-turn `active_files` would otherwise bust the cache).
+- **R3 — cluster-before-promote:** `promote_procedures` collapses near-duplicate-GOAL workflows via a lexical Jaccard test (`_near_dup_goal`) — no embedder/memem dependency, task-agnostic — keeping the higher-frequency one.
+- **R2 — config:** `AGENT_MINE` gates consolidation end-to-end (off → skip; deterministic → recorded; llm → generalized).
+- **R4 / B-EM2 (queryless snapshot) — DEFERRED:** both require **memem API changes** the current interface doesn't expose (`memory_save` has no `supersedes`; `retrieve` has no queryless mode), and the user's standing rule is to keep memem behind its interface. R4's intent is partially served by memem's own merge-band dedup (0.70–0.92 → merge). B-EM1 (multi-section render) deferred as low-value: memem-recalled items are predominantly one kind (corrective facts); skills already live in a separate tier.
+
+**Verification:** offline suite **103/103 green** (added B1/B2/R1/R3 tests in `test_consolidate.py`; migrated the removed-miner behavior; updated stale fakes for the new optional params). Live `/learn` probe (`evals/probe_learn.py`) **PASS**.
+
+---
+
+## Adversarial review (2026-06-25) — verdict + fixes
+
+A 4-lens adversarial review (invariant · security · correctness · integration) + synthesis ran over the changes.
+
+**Confirmed safe:** the cache-only-distill invariant holds (no layer-skip); F1 sends no secret/injection to the LLM; `write_skill` cannot forge AUTO provenance, escape the skills dir, or persist an unscanned body; `promote_episodes` self-inflicted selection is correct; R1 does not bust the per-topic recall cache; R3's Jaccard does not over-collapse distinct intents; no dangling `LessonMiner` references.
+
+**One real defect found + fixed (root-cause).** `pagetable._episodes_search_thissession` overloaded the `exclude_session` field as `only_session` — it worked only because every caller happened to pass the current session id. It did **not** leak in practice (the only caller, `history.py`, set it; the slice's `PageTable` — which left it `None` — never invokes that kind), so the reviewer's "leaks via slice.py" severity was over-stated. But it was a foot-gun one wiring change away from a cross-session leak. Fixed at the invariant level: `PageTable` now holds **one** `session_id` (cross-session reads EXCLUDE it; within-session reads filter ONLY to it), the within-session content search **fails closed** when no session is set (`not self.session_id → []`, never `only_session=None`), and both construction sites pass it. Regression test: `thissession_search_fails_closed_without_a_session`.
+
+**Defense-in-depth (the two low F1 notes), also closed.** `render_skill_llm` now `redact_text`s and `scan_for_threats`-checks the LLM's **return** body (not just the input material) before emitting, so a secret/injection the model might produce never lives in the skill string even transiently — independent of the downstream `write_skill_file` sanitize.
+
+**Final:** suite **103/103 green** (incl. the new fail-closed regression); live `/learn` PASS. No open findings.

--- a/evals/probe_learn.py
+++ b/evals/probe_learn.py
@@ -1,0 +1,79 @@
+"""LIVE end-to-end test of #3 — transcript → reusable SKILL via /learn (B2). Runs a small real task
+(builds the episodic CACHE), then runs the /learn turn (build_learn_prompt) with the agent holding
+recall_history + write_skill; asserts the agent distilled a USER-provenance SKILL.md FROM THE CACHE.
+UNCOMMITTED. Run (DeepSeek, proxy off):
+  set -a; source "/Users/tongtao/Desktop/agent design/.env"; set +a; unset HTTP_PROXY HTTPS_PROXY
+  LLM_API_KEY=$DEEPSEEK_API_KEY LLM_BASE_URL=https://api.deepseek.com/v1 AGENT_MODEL=deepseek-chat \
+    PYTHONPATH=src .venv/bin/python evals/probe_learn.py
+"""
+import glob
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+def main():
+    os.environ["MEMAGENT_VAULT"] = tempfile.mkdtemp(prefix="learn-vault-")
+    sk = tempfile.mkdtemp(prefix="learn-skills-")
+    os.environ["MEMAGENT_SKILLS_DIR"] = sk
+    model = os.environ.get("AGENT_MODEL", "deepseek-chat")
+
+    from memagent.memory import make_memory, make_write_skill_tool
+    from memagent.history import make_history_tool
+    from memagent.code_grep import make_grep_tool
+    from memagent.consolidate import build_learn_prompt
+    from memagent.slice import Slice, make_build_slice, slice_sink, record_user, one_line
+    from memagent.episode import make_episode_sink
+    from memagent.events import AssistantText, ToolResult, make_dispatcher
+    from memagent.retriever import NullRetriever
+    from memagent.llm import OpenAILLM
+    from memagent.loop import run_turn
+
+    sid = "learn-probe"
+    wd = tempfile.mkdtemp(prefix="learn-wd-")
+    mem = make_memory()
+    host = make_grep_host = __import__("memagent.tools", fromlist=["LocalToolHost"]).LocalToolHost(root=wd)
+    host.registry.register(make_grep_tool(host))
+    host.registry.register(make_history_tool(mem, sid))
+    host.registry.register(make_write_skill_tool())
+    state = Slice()
+    tools_seen = []
+    def cap(e):
+        if isinstance(e, ToolResult):
+            tools_seen.append(e.name)
+    episodic = make_episode_sink(mem, session_id=sid, task_id_fn=lambda: "t", title_fn=lambda: one_line(state.goal, 80))
+    dispatch = make_dispatcher(slice_sink(state), episodic, cap)
+    llm = OpenAILLM(model=model, timeout=120.0); llm.set_cache_key(sid)
+    build = make_build_slice(state, host, NullRetriever(), mem, "", session_id=sid)
+
+    def turn(prompt):
+        state.goal = prompt
+        record_user(state, prompt)
+        run_turn(build_slice=build, llm=llm, tools=host, dispatch=dispatch, max_steps=12)
+
+    print(f"# /learn live probe · model={model} · vault={'memem' if getattr(mem,'is_durable',False) else 'null'}")
+    # 1) a small real workflow → fills the episodic cache
+    turn("Create greet.py with a function greet(name) that returns 'Hello, '+name, then run it with python "
+         "to print greet('world').")
+    # 2) /learn — the agent must read THIS session from the cache and author a skill via write_skill
+    tools_seen.clear()
+    turn(build_learn_prompt("the workflow we just did — making and running a small Python script"))
+
+    skills = glob.glob(os.path.join(sk, "*", "SKILL.md"))
+    print(f"called write_skill: {'write_skill' in tools_seen}  |  used recall_history: {'recall_history' in tools_seen}")
+    print(f"skills written: {len(skills)}")
+    ok = False
+    if skills:
+        body = open(skills[0]).read()
+        ok = "provenance: user" in body and body.lstrip().startswith("---")
+        print(f"  {os.path.relpath(skills[0], sk)}: provenance-user={('provenance: user' in body)} "
+              f"valid-frontmatter={body.lstrip().startswith('---')}")
+        print("  --- head ---"); print("  " + "\n  ".join(body.splitlines()[:12]))
+    print(f"\n==================== /learn {'PASS' if ok else 'FAIL'} ====================")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/memagent/cli.py
+++ b/src/memagent/cli.py
@@ -146,7 +146,6 @@ def main() -> None:
     from .mcp_client import connect_mcp_servers
     from .loop import run_turn
     from .memory import make_memory
-    from .mining import make_miner
     from .oracle import CommandOracle
     from .plugins import load_plugins
     from .policy import make_policy
@@ -189,6 +188,10 @@ def main() -> None:
         from .web import make_web_tools
         for _wt in make_web_tools(base_tools):
             base_tools.registry.register(_wt)
+    # foreground SKILL writer — the agent-callable tool /learn drives to turn a transcript into a
+    # reusable USER-provenance skill (guarded write: validate + threat-scan + redact + atomic).
+    from .memory import make_write_skill_tool
+    base_tools.registry.register(make_write_skill_tool())
     # MCP: connect config + plugin-declared servers; tools register into the SAME registry
     mcp_servers, mcp_runtime = connect_mcp_servers(
         base_tools.registry, {**cfg.mcp_servers, **plugin_mcp}, on_log=lambda m: print(f"  · {m}"))
@@ -220,11 +223,9 @@ def main() -> None:
         from .history import make_history_tool
         base_tools.registry.register(make_history_tool(memory, session.session_id))
 
-    # write side of the memory loop: mine a lesson per successful, error-resolving turn
-    miner = None
-    if mine_mode not in ("0", "off", "none"):
-        miner = make_miner(memory, session, llm=llm, mode=mine_mode,
-                           scope=os.path.basename(root) or "default")
+    # write side of the memory loop is CACHE-ONLY: distillation runs at session end in
+    # memory.consolidate (reads the episodic cache, never the slice). `mine_mode` (off|deterministic|llm)
+    # gates that consolidation — see the session-end call below. No per-turn slice-coupled miner.
     # OPT-IN async background-review fork (item 16; OFF unless AGENT_BACKGROUND_REVIEW set).
     # Reads the durable episodic cache off-thread and consolidates incrementally — never
     # touches the slice/loop/prompt. None when disabled, so the default path is unchanged.
@@ -307,10 +308,9 @@ def main() -> None:
             return a or "(no answer)"
         base_tools.on_ask_user = _ask_user
 
-    # sinks: update the active slice from tool results, mine lessons, cache the turn, persist, print
+    # sinks: update the active slice from tool results, cache the turn, persist, print (no per-turn
+    # miner — distillation is cache-only at session end via memory.consolidate).
     sinks = [slice_sink(session)]
-    if miner is not None:
-        sinks.append(miner)
     if episodic is not None:
         sinks.append(episodic)
     sinks.append(log_sink())
@@ -346,8 +346,6 @@ def main() -> None:
         print(f"  · slice monitor: writing to {_monitor_dir()} — view at the persistent server "
               "(run: python -m memagent.monitor)")
     dispatch = make_dispatcher(*sinks)
-    if miner is not None:
-        miner.dispatch = dispatch  # late-bind so LessonSaved flows through log + terminal sinks
     if app is not None:            # inject the dispatcher the app (created earlier) re-runs turns through
         app._dispatch = dispatch
 
@@ -464,7 +462,7 @@ def main() -> None:
             f"policy={policy_mode} · sandbox={cfg.sandbox_backend} · "
             f"code={type(retriever).__name__} · memory={type(memory).__name__} · "
             f"episodic={'on' if episodic is not None else 'off'} · "
-            f"mine={mine_mode if miner is not None else 'off'} · subagents={'on' if sub_depth > 0 else 'off'} · "
+            f"mine={mine_mode} · subagents={'on' if sub_depth > 0 else 'off'} · "
             f"skills={len(skills.names())} · mcp_tools={mcp_tool_count} · plugin_tools={plugin_tool_count}")
     # ── choose UI: full-screen Textual (terminal-only) or the original rich+prompt_toolkit REPL ──
     _input = _tui.TuiInput(_stats, root=root) if _tui else None
@@ -561,7 +559,10 @@ def main() -> None:
                 break
             if not line:
                 continue
-            if _tui and line.startswith("/"):                  # navigation palette (no turn)
+            if line == "/learn" or line.startswith("/learn "):  # transcript → reusable skill (runs as a turn)
+                from .consolidate import build_learn_prompt
+                line = build_learn_prompt(line[len("/learn"):].strip())
+            elif _tui and line.startswith("/"):                # navigation palette (no turn)
                 _handle_slash(line)
                 continue
             # INVARIANT: echo the user's line BEFORE any blocking work (esp. route_topic's LLM round-trip),
@@ -630,9 +631,11 @@ def main() -> None:
     _safe("tool cleanup", base_tools.cleanup)
     if mcp_runtime is not None:        # #61/#62: a stuck MCP server must not freeze exit → bounded shutdown
         _bounded("MCP shutdown", mcp_runtime.shutdown)
-    # consolidate the episodic cache into long-term memory (the cache→memory loop)
-    if getattr(memory, "is_durable", False):
-        _safe("memory consolidation", lambda: memory.consolidate(session.session_id))
+    # consolidate the episodic cache into long-term memory (the cache→memory loop). mine_mode gates it:
+    # off → skip; deterministic → recorded skills; llm → render_skill_llm generalizes (scan-first).
+    if getattr(memory, "is_durable", False) and mine_mode not in ("0", "off", "none"):
+        _safe("memory consolidation",
+              lambda: memory.consolidate(session.session_id, llm=llm, mode=mine_mode))
         print("  · consolidated session memory")
     _safe("memory close", getattr(memory, "close", lambda: None))   # #33: close the FTS5 index (WAL checkpoint)
     if metrics is not None:                                 # the moat number: per-turn fresh-input curve

--- a/src/memagent/consolidate.py
+++ b/src/memagent/consolidate.py
@@ -14,12 +14,18 @@ body is a RECORDED procedure; LLM-distillation (generalizing the steps) is the c
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 from collections import Counter
 
 from .finding_types import badge, classify_finding
+from .mining import is_self_inflicted   # the cache-distill path now owns self-inflicted filtering
+from .safety import redact_text, scan_for_threats   # F1: scan recorded material BEFORE the LLM call + the return
+from .skill_provenance import AUTO, frontmatter_line
 from .slice import one_line
+
+_log = logging.getLogger("memagent.consolidate")
 
 PROC_MIN_ACTIONS = 3     # a workflow worth a skill = at least this many meaningful actions
 MAX_PROCEDURES = 3       # cap skills promoted per session (avoid spam)
@@ -44,14 +50,6 @@ def _is_secret(text: str) -> bool:
     return bool(_SECRET_RE.search(text or ""))
 
 
-def _failing_obs(record: dict) -> str:
-    for st in record.get("steps", []):
-        for o in st.get("observation", []):
-            if isinstance(o, str) and (o.startswith("Error") or o.startswith("Exit code")):
-                return o
-    return ""
-
-
 def _by_task(records: list[dict]) -> list[list[dict]]:
     groups: dict[str, list[dict]] = {}
     for r in records:
@@ -71,7 +69,13 @@ def promote_episodes(records: list[dict]) -> list[dict]:
         last = rmeta[-1].get("meta", {})
         if not (had_fail and last.get("stop_reason") == "end_turn" and not last.get("failing")):
             continue
-        pitfall = next((p for m in reversed(rmeta) if (p := _failing_obs(m))), "")
+        # all failing observations across the task's turns, oldest→newest; pick the LAST NON-self-
+        # inflicted one. A turn whose only failures are the agent hitting its OWN sandbox teaches
+        # nothing, but a real error AFTER a self-inflicted one must still be mined (the removed live
+        # miner's D2 behaviour, now owned by this cache path).
+        fails = [o for m in rmeta for st in m.get("steps", []) for o in st.get("observation", [])
+                 if isinstance(o, str) and (o.startswith("Error") or o.startswith("Exit code"))]
+        pitfall = next((o for o in reversed(fails) if not is_self_inflicted(o)), "")
         if not pitfall or _is_secret(pitfall):
             continue
         note = next((m.get("note") for m in reversed(rmeta) if m.get("note")), "")
@@ -94,8 +98,59 @@ def promote_episodes(records: list[dict]) -> list[dict]:
         ftype = classify_finding(c["note"], edited=bool(c["files"]), had_error=True, resolved=True)
         title = badge(ftype) + "Lesson: " + (one_line(c["note"], 60) or one_line(c["pitfall"], 60))
         out.append({"title": title, "content": content, "tags": _tags(c["files"]),
-                    "kind": "fact", "freq": n, "finding_type": ftype})
+                    "kind": "fact", "freq": n, "finding_type": ftype, "files": c["files"]})  # files: R1 tag
     return out
+
+
+# ── B2: /learn — turn the session transcript into a reusable USER skill (Hermes pattern) ──────────
+_LEARN_STANDARDS = """\
+Author the skill to this standard:
+- name: lowercase-hyphenated, no spaces.
+- description: ONE sentence, <=60 chars, stating the CAPABILITY (not the implementation); no marketing words.
+- body sections, in order (omit one only if genuinely empty):
+  ## When to use   - concrete trigger phrases / situations.
+  ## Process       - numbered, GENERALIZED steps (declarative, NOT this session's verbatim commands).
+  ## Pitfalls      - gotchas / things that look broken but aren't (or 'none known').
+  ## Verification  - one check that proves it worked.
+- Reference memagent's own tools by name (read_file, grep, edit_file, run_command) - not raw shell utilities.
+- Be tight (~60-150 lines). Prefer exact signatures/commands/paths from the source; NEVER invent flags or APIs.
+- Do not write a skill that only points at other skills."""
+
+
+def build_learn_prompt(user_request: str = "") -> str:
+    """B2 (Hermes /learn pattern): build ONE prompt that has the LIVE agent distill a reusable skill from
+    the source the user named and save it via the `write_skill` tool. No separate distill engine + no new
+    LLM seam (llm-agnostic, works on any backend); the agent reads THIS session from the CACHE via
+    recall_history (never the slice), honoring the cache-only-distill invariant."""
+    req = (user_request or "").strip() or ("the workflow we just went through in this session - review the "
+                                            "steps taken and distill them into a reusable skill")
+    return (
+        "[/learn] Distill a REUSABLE SKILL from the source below and save it with the write_skill tool.\n\n"
+        f"WHAT TO LEARN FROM:\n{req}\n\n"
+        "Do this:\n"
+        "1. Gather the material with the tools you already have: recall_history (review THIS session's "
+        "earlier turns - the lossless cache), read_file / grep for files, the recent conversation for "
+        "'what we just did'. If the scope is ambiguous, make a reasonable choice and note it; do not stall.\n"
+        "2. Call write_skill ONCE with a name, a <=60-char description, and the body. After it succeeds, "
+        "tell the user the skill name and a one-line summary of what it captured.\n\n"
+        f"{_LEARN_STANDARDS}"
+    )
+
+
+_GOAL_STOP = frozenset("the a an to of in for and or with on at by add fix make build update create".split())
+
+
+def _goal_tokens(s: str) -> set:
+    return {t for t in re.findall(r"[a-z0-9]+", (s or "").lower()) if t not in _GOAL_STOP and len(t) > 2}
+
+
+def _near_dup_goal(a: str, b: str, thresh: float = 0.6) -> bool:
+    """R3 (EverOS cluster-before-promote, lexical): two procedure goals are the same INTENT if their
+    content-token sets overlap heavily (Jaccard). No embedder/memem dependency — task-agnostic."""
+    ta, tb = _goal_tokens(a), _goal_tokens(b)
+    if not ta or not tb:
+        return False
+    return len(ta & tb) / len(ta | tb) >= thresh
 
 
 def _slug(text: str) -> str:
@@ -137,32 +192,75 @@ def promote_procedures(records: list[dict], *, min_actions: int = PROC_MIN_ACTIO
         cand.append({"shape": "→".join(names), "goal": goal,
                      "steps": [_op_hint(a) for a in actions][:12], "files": files})
     sig_freq = Counter(c["shape"] for c in cand)
-    out, seen = [], set()
+    out, seen, kept_goals = [], set(), []
     for c in sorted(cand, key=lambda c: sig_freq[c["shape"]], reverse=True):
         if c["shape"] in seen:
             continue
-        seen.add(c["shape"])
+        if any(_near_dup_goal(c["goal"], g) for g in kept_goals):   # R3: collapse same-INTENT workflows
+            continue                                                # (keep the higher-freq one, sorted first)
+        seen.add(c["shape"]); kept_goals.append(c["goal"])
         out.append({"kind": "procedure", "name": _slug(c["goal"]), "description": one_line(c["goal"], 80),
                     "steps": c["steps"], "files": c["files"], "freq": sig_freq[c["shape"]],
                     "tags": _tags(c["files"])})
         if len(out) >= cap:
             break
+    dropped = len(sig_freq) - len(out)          # F3: surface the silent cap instead of dropping quietly
+    if dropped > 0:
+        _log.debug("promote_procedures: capped at %d; dropped %d lower-frequency procedure(s)", cap, dropped)
     return out
 
 
-def render_skill(proc: dict) -> str:
+def render_skill(proc: dict, *, origin: str = AUTO) -> str:
     """A procedure → a SKILL.md (Kimi format: name/description frontmatter + When-to-use/Process).
-    Deterministic = a RECORDED procedure; the LLM-distill upgrade (generalizing the steps) slots in
-    here without changing callers. Stamps a `provenance:` frontmatter field (item 13) marking the
-    skill consolidation-AUTHORED, so a future curator prunes ONLY auto skills, never user skills."""
-    from .skill_provenance import AUTO, frontmatter_line
+    DETERMINISTIC = a RECORDED procedure (the steps verbatim). `render_skill_llm` is the LLM-generalized
+    upgrade. Stamps a `provenance:` field (item 13: AUTO=consolidation, USER=foreground /learn) so a
+    curator prunes only auto skills."""
     steps = "\n".join(f"{i + 1}. {s}" for i, s in enumerate(proc.get("steps", []))) or "(no steps)"
     n = proc.get("freq", 1)
-    prov = f"Auto-distilled from {n} successful run(s) this session." if n > 1 else \
-        "Auto-distilled from a successful run."
+    prov = f"Observed from {n} successful run(s) this session." if n > 1 else \
+        "Observed from a successful run."
     return (f"---\nname: {proc['name']}\ndescription: {proc['description']}\n"
-            f"{frontmatter_line(AUTO)}\n---\n\n"
+            f"{frontmatter_line(origin)}\n---\n\n"
             f"# {proc['description']}\n\n{prov}\n\n"
             f"## When to use\n{proc['description']}\n\n"
             f"## Process (observed)\n{steps}\n\n"
             f"## Files\n{', '.join(proc.get('files', [])) or 'n/a'}\n")
+
+
+# ── B1: LLM-generalized skill body (the upgrade render_skill was stubbed for) ──────────────────────
+_GENERALIZE_SYS = (
+    "You turn a RECORDED procedure (the exact steps an agent took) into a REUSABLE skill body for a "
+    "future agent. Generalize: state when to use it, the process as declarative steps (not this session's "
+    "verbatim commands), and 1-3 pitfalls. Markdown only, no preamble. Output EXACTLY these sections and "
+    "nothing else:\n## When to use\n<concrete trigger phrases>\n## Process\n<numbered, generalized steps>\n"
+    "## Pitfalls\n<gotchas, or 'none known'>"
+)
+
+
+def render_skill_llm(proc: dict, llm, *, origin: str = AUTO) -> str:
+    """B1 — render a skill whose BODY is LLM-generalized from the recorded steps (the upgrade the
+    deterministic `render_skill` was stubbed for). The frontmatter stays DETERMINISTIC (name/description/
+    provenance) so the SkillManager always parses it. F1: scan the recorded material BEFORE the LLM call —
+    never send a secret to distillation. Falls back to the deterministic `render_skill` on no-llm, a
+    threat hit, or any LLM failure, so this is a safe drop-in."""
+    if llm is None:
+        return render_skill(proc, origin=origin)
+    steps = "\n".join(f"{i + 1}. {s}" for i, s in enumerate(proc.get("steps", []))) or "(no steps)"
+    material = f"Goal: {proc.get('description', '')}\nFiles: {', '.join(proc.get('files', []))}\nSteps:\n{steps}"
+    if _is_secret(material) or scan_for_threats(material, scope="strict"):
+        return render_skill(proc, origin=origin)            # F1: tainted → deterministic, no LLM
+    try:
+        resp = llm.complete([{"role": "system", "content": _GENERALIZE_SYS},
+                             {"role": "user", "content": material}], [])
+        body = (resp.content or "").strip()
+    except Exception:  # noqa: BLE001 — any LLM failure falls back, never breaks consolidation
+        body = ""
+    body = redact_text(body)                                 # F1 (return path): never emit a leaked secret…
+    if scan_for_threats(body, scope="strict"):              # …or an injection the LLM may have produced
+        return render_skill(proc, origin=origin)
+    if "## When to use" not in body or "## Process" not in body:
+        return render_skill(proc, origin=origin)            # invalid/empty → deterministic fallback
+    n = proc.get("freq", 1)
+    prov = f"Generalized from {n} successful run(s)." if n > 1 else "Generalized from a successful run."
+    return (f"---\nname: {proc['name']}\ndescription: {proc['description']}\n"
+            f"{frontmatter_line(origin)}\n---\n\n# {proc['description']}\n\n{prov}\n\n{body}\n")

--- a/src/memagent/history.py
+++ b/src/memagent/history.py
@@ -145,7 +145,7 @@ def make_history_tool(memory, session_id: str):
     guard = {"seen": -1, "served": set(), "distinct": 0}   # episode count, fetches served, drills
     # The ONE cross-session read path: PageTable's episode-xsession backend wraps
     # memory.search_episodes (the this-session read_episodes drill stays in this handler).
-    pages = PageTable(memory=memory, exclude_session=session_id)
+    pages = PageTable(memory=memory, session_id=session_id)
 
     def _handler(args: dict) -> str:
         # content-search shape: search=... runs FTS5 over THIS session's long tail (turns past the

--- a/src/memagent/memory.py
+++ b/src/memagent/memory.py
@@ -75,6 +75,63 @@ def _skills_dir() -> str:
                               or os.path.join("~", ".memagent", "skills"))
 
 
+def write_skill_file(name: str, body: str, *, skills_dir: str | None = None) -> str | None:
+    """Persist ONE SKILL.md to the skills dir, the single guarded writer shared by auto-consolidation
+    and the foreground /learn tool. Validates the frontmatter, BLOCKS on a threat scan (a poisoned skill
+    re-injects unscanned every session), REDACTS any secret before it lands on disk, and writes
+    atomically. Returns the path written, or None if rejected. Never raises."""
+    try:
+        name = re.sub(r"[^a-z0-9._-]+", "-", (name or "").strip().lower()).strip("-")[:64] or "skill"
+        if not body.lstrip().startswith("---") or "name:" not in body[:200]:
+            return None                                  # not a valid SKILL.md (frontmatter required)
+        if scan_for_threats(body, scope="strict"):       # (a) BLOCK on write — poisoned skill
+            return None
+        d = os.path.join(skills_dir or _skills_dir(), name)
+        os.makedirs(d, exist_ok=True)
+        path = os.path.join(d, "SKILL.md")
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(redact_text(body))                   # (c) redact any secret before persisting
+        os.replace(tmp, path)                            # atomic
+        return path
+    except Exception:  # noqa: BLE001 — a skill-write failure must never break the caller
+        return None
+
+
+def make_write_skill_tool():
+    """The FOREGROUND skill writer (the tool /learn drives) — the agent-callable writer memagent lacked.
+    The agent supplies name/description/body; WE own the frontmatter (provenance: user — never
+    auto-pruned) and the guarded write (validate + threat-scan + redact + atomic), so a model can't forge
+    AUTO provenance or smuggle an unscanned skill onto disk."""
+    from .registry import ToolEntry
+    from .skill_provenance import USER, frontmatter_line
+
+    def handler(args: dict) -> str:
+        name = re.sub(r"[^a-z0-9._-]+", "-", (args.get("name") or "").strip().lower()).strip("-")[:64]
+        desc = (args.get("description") or "").strip().replace("\n", " ")[:120]
+        body = (args.get("body") or "").strip()
+        if not name or not desc or not body:
+            return "write_skill: need a name, a description, and a body."
+        md = f"---\nname: {name}\ndescription: {desc}\n{frontmatter_line(USER)}\n---\n\n{body}\n"
+        path = write_skill_file(name, md)
+        if not path:
+            return "write_skill: rejected (invalid frontmatter, empty, or flagged by the security scan)."
+        return f"Skill saved to {path} (provenance: user — it will load next session)."
+
+    schema = {"type": "function", "function": {
+        "name": "write_skill",
+        "description": ("Save a REUSABLE skill (SKILL.md) authored by you, so a FUTURE session can load and "
+                        "reuse it. Provide a lowercase-hyphenated `name`, a <=60-char `description` of the "
+                        "capability, and the markdown `body` (## When to use / ## Process / ## Pitfalls / "
+                        "## Verification). This is how /learn turns what you just did into a durable skill."),
+        "parameters": {"type": "object", "properties": {
+            "name": {"type": "string", "description": "lowercase-hyphenated skill name (no spaces)"},
+            "description": {"type": "string", "description": "one sentence, <=60 chars, the capability"},
+            "body": {"type": "string", "description": "the skill body markdown (sections as above)"},
+        }, "required": ["name", "description", "body"]}}}
+    return ToolEntry(name="write_skill", schema=schema, handler=handler, source="builtin")
+
+
 # --- task-state markdown (de)serialization — pure module fns (no memem) -------------------
 
 def _split_frontmatter(text: str) -> tuple[dict, str]:
@@ -232,7 +289,7 @@ class NullMemory:
 
     is_durable = False
 
-    def recall(self, query: str, k: int = 6) -> list[Snippet]:
+    def recall(self, query: str, k: int = 6, paths: list[str] | None = None) -> list[Snippet]:
         return []
 
     def remember(self, content: str, *, title: str = "", scope: str = "default", tags: str = "") -> None:
@@ -280,15 +337,16 @@ class MememMemory:
         self._scope = os.path.basename(os.getcwd()) or "default"   # same-project soft bonus on recall
 
     # --- lessons ---
-    def recall(self, query: str, k: int = 6) -> list[Snippet]:
+    def recall(self, query: str, k: int = 6, paths: list[str] | None = None) -> list[Snippet]:
         """Recall cross-session lessons, then GATE by relevance: drop hits that share no term with
         the goal (memem returns top-k with no floor → cross-domain noise). Pass scope_id so same-
-        project lessons get memem's soft bonus, and REINFORCE the surfaced (relevant) ones via
-        mark_used — so retrieval feedback tracks what we actually show, not raw top-k. Decay of the
-        unreinforced is memem's own job (compute_decay_factor over access_count)."""
+        project lessons get memem's soft bonus, and `paths` (R1, the files in play at topic-start) so
+        memem's paths_context gives lessons tagged with those files a small bonus. REINFORCE the
+        surfaced (relevant) ones via mark_used. Decay of the unreinforced is memem's own job."""
         from memem.retrieve import retrieve
         try:
-            hits = retrieve(query, k=k, log_call_type=None, writeback=False, scope_id=self._scope)
+            hits = retrieve(query, k=k, log_call_type=None, writeback=False, scope_id=self._scope,
+                            paths_context=paths or None)
         except Exception:
             return []
         terms = _terms(query)
@@ -301,7 +359,8 @@ class MememMemory:
             out.append(Snippet(path=h.get("path", ""), text=text, score=float(h.get("score", 0.0))))
         return out
 
-    def remember(self, content: str, *, title: str = "", scope: str = "default", tags: str = "") -> None:
+    def remember(self, content: str, *, title: str = "", scope: str = "default", tags: str = "",
+                 paths: list[str] | None = None) -> None:
         # (a) BLOCK on WRITE: a poisoned lesson would re-inject into the slice every turn forever.
         if scan_for_threats(f"{title}\n{content}", scope="strict"):
             return
@@ -310,7 +369,7 @@ class MememMemory:
         title = redact_text(title)
         from memem.operations import memory_save
         try:
-            memory_save(content, title=title, scope_id=scope, tags=tags)
+            memory_save(content, title=title, scope_id=scope, tags=tags, paths=paths or None)  # R1: tag with files
         except Exception:
             pass
 
@@ -460,32 +519,24 @@ class MememMemory:
         except Exception:
             return []
 
-    def consolidate(self, session_id: str) -> None:
-        """Session-end sweep: promote durable knowledge from the episodic cache, ROUTED BY TYPE —
-        FACTS (corrective lessons) → long-term memory (memem remember); PROCEDURES (repeated smooth
-        workflows) → reusable SKILL.md files the SkillManager discovers next session. Both are
-        frequency-weighted. Never raises (a consolidation failure must not break the session)."""
+    def consolidate(self, session_id: str, *, llm=None, mode: str = "deterministic") -> None:
+        """Session-end sweep: promote durable knowledge from the episodic CACHE (never the slice),
+        ROUTED BY TYPE — FACTS (corrective lessons) → memem; PROCEDURES (repeated smooth workflows) →
+        reusable SKILL.md the SkillManager discovers next session. `mode="llm"` (with an `llm`) renders
+        skill bodies via render_skill_llm (generalized) instead of render_skill (recorded); both fall
+        back to deterministic on any failure. Never raises."""
         try:
-            from .consolidate import promote_episodes, promote_procedures, render_skill
+            from .consolidate import promote_episodes, promote_procedures, render_skill, render_skill_llm
             records = self.read_episodes(session_id)
             if not records:
                 return
-            for lesson in promote_episodes(records):                 # facts → memem
+            for lesson in promote_episodes(records):                 # facts → memem (tagged with files: R1)
                 self.remember(lesson["content"], title=lesson["title"], scope=self._scope,
-                              tags=lesson["tags"])
+                              tags=lesson["tags"], paths=lesson.get("files"))
             skills_dir = _skills_dir()
-            for proc in promote_procedures(records):                 # procedures → skill packs
-                try:
-                    body = render_skill(proc)
-                    # (a) BLOCK on WRITE: a poisoned SKILL.md re-injects unscanned every session.
-                    if scan_for_threats(body, scope="strict"):
-                        continue
-                    d = os.path.join(skills_dir, proc["name"])
-                    os.makedirs(d, exist_ok=True)
-                    with open(os.path.join(d, "SKILL.md"), "w", encoding="utf-8") as f:
-                        f.write(redact_text(body))   # (c) redact any secret before it lands on disk
-                except Exception:
-                    pass
+            for proc in promote_procedures(records):                 # procedures → skill packs (AUTO)
+                body = (render_skill_llm(proc, llm) if mode == "llm" else render_skill(proc))
+                write_skill_file(proc["name"], body, skills_dir=skills_dir)   # guarded writer (scan+redact)
         except Exception:
             pass
 

--- a/src/memagent/mining.py
+++ b/src/memagent/mining.py
@@ -1,42 +1,31 @@
-"""Lesson mining — the WRITE side of the memory loop.
+"""Lesson-mining HELPERS — shared by the CACHE-sourced distill path.
 
-The read side recalls lessons into the RELEVANT MEMORY tier. This closes the loop:
-after a task SUCCEEDS, distill a durable lesson from what happened (the pitfall that
-was hit, and that it was resolved) and remember() it into memem — so a future similar
-task recalls it. That's what makes memagent memory-NATIVE rather than memory-using.
+The WRITE side of the memory loop is CACHE-ONLY: distillation happens at session end in
+`memory.consolidate` → `consolidate.promote_episodes` / `promote_procedures`, which read the episodic
+CACHE (`read_episodes`), never the live slice. The old per-turn `LessonMiner` that read slice state
+(`s.edited_files`, `s.last_error`) was removed so distill no longer couples to L1 — the layering is
+now strictly  L1 slice ─seal→ L2 cache ─distill→ L3 memem ─recall→ L1 slice.
 
-It's an event SINK (like slice_sink / log_sink) holding a ref to the slice for task
-and outcome context — so the loop and the moat never change, and memem stays behind
-the Memory interface. Signal-dense by construction: it mines ONLY a validated episode
-— a successful turn (end_turn) in which an error was encountered and then cleared. No
-error, no success, no lesson. An optional one-shot LLM pass distills a crisper lesson.
+These pure helpers — error-signature dedup, self-inflicted-error filtering, and pitfall titling — are
+reused by that cache path (and the tests). No slice import; no event sink.
 """
 from __future__ import annotations
 
 import re
 
-from .events import Event, LessonSaved, ToolResult, TurnEnd
-from .slice import _active, one_line
+from .text_utils import one_line
 from .tools import HOST_ERROR_SENTINELS
-
-# touched-file extensions → coarse tags (helps recall group lessons by stack)
-_EXT_TAG = {
-    ".py": "python", ".js": "javascript", ".ts": "typescript", ".tsx": "typescript",
-    ".go": "go", ".rs": "rust", ".java": "java", ".rb": "ruby", ".c": "c", ".cpp": "cpp",
-    ".sh": "shell",
-}
 
 
 def _err_key(err: str) -> str:
-    """A stable-ish signature for an error, for in-session dedup."""
+    """A stable-ish signature for an error, for dedup."""
     return one_line(err, 100).lower()
 
 
 def is_self_inflicted(pitfall: str) -> bool:
     """D2 — True when `pitfall` is the agent hitting the HOST's own guard rail (confinement,
-    permission), not a real engineering pitfall. Such an error teaches a future agent nothing about
-    the user's code, so it must mine NOTHING. Task-agnostic: substring match against the host's own
-    error sentinels (defined in tools.py, the source of those messages)."""
+    permission), not a real engineering pitfall. Such an error teaches a future agent nothing, so it
+    must mine NOTHING. Task-agnostic substring match against the host's error sentinels (tools.py)."""
     low = (pitfall or "").lower()
     return any(sentinel in low for sentinel in HOST_ERROR_SENTINELS)
 
@@ -47,133 +36,7 @@ _ERR_PREFIX_RE = re.compile(r"^\s*(?:error|exit code \d+)\s*[:\-]?\s*", re.I)
 
 
 def pitfall_signature(pitfall: str, n: int = 60) -> str:
-    """D1 — distil a short, readable lesson TITLE from the PITFALL itself (never the user's goal).
-    Strips the host's 'Error:'/'Exit code:' prefix so the title leads with the real failure."""
+    """D1 — a short, readable lesson TITLE from the PITFALL itself (never the user's goal). Strips the
+    host's 'Error:'/'Exit code:' prefix so the title leads with the real failure."""
     sig = _ERR_PREFIX_RE.sub("", one_line(pitfall, 200)).strip()
     return one_line(sig or pitfall, n)
-
-
-class LessonMiner:
-    """Event sink that mines a lesson per successful, error-resolving turn.
-
-    Pass it as a sink. Late-bind `.dispatch` after the dispatcher is built so the
-    LessonSaved event flows through the same log/terminal sinks as everything else.
-    """
-
-    def __init__(self, memory, state, *, llm=None, mode: str = "deterministic",
-                 scope: str = "default"):
-        self.memory = memory
-        self.state = state
-        self.llm = llm
-        self.mode = mode            # "deterministic" | "llm"
-        self.scope = scope
-        self.dispatch = None        # late-bound; emits LessonSaved
-        self._errors: list[str] = []   # errors seen this turn (in order)
-        self._saved: set[str] = set()  # error signatures saved this session (dedup)
-
-    def __call__(self, event: Event) -> None:
-        if isinstance(event, ToolResult):
-            if event.failing and event.output:
-                self._errors.append(event.output)
-        elif isinstance(event, TurnEnd):
-            try:
-                self._on_turn_end(event)
-            finally:
-                self._errors = []  # reset per-turn buffer regardless
-
-    # --- mining ----------------------------------------------------------
-    def _on_turn_end(self, event: TurnEnd) -> None:
-        # validated CORRECTIVE episode only: success + an error hit AND cleared AND an actual FIX made.
-        # The edit requirement is the key gate: an error with NO edit (e.g. read_file on a directory,
-        # or any incidental/self-inflicted failure) is not a lesson — without it we mine junk like
-        # "Lesson: <the user's query>" from a turn that changed nothing.
-        if event.stop_reason != "end_turn":
-            return
-        s = _active(self.state)
-        if not self._errors or s.last_error or not s.edited_files:
-            return
-        # D2 — choose the last NON-self-inflicted error as the pitfall. A turn whose only failures are
-        # the agent hitting its OWN sandbox (confinement/permission) teaches nothing → mine nothing.
-        pitfall = next((e for e in reversed(self._errors) if not is_self_inflicted(e)), "")
-        if not pitfall:
-            return
-        key = _err_key(pitfall)
-        if key in self._saved:
-            return
-
-        title, content, tags = self._build(pitfall)
-        if not content:
-            return
-        try:
-            self.memory.remember(content, title=title, scope=self.scope, tags=tags)
-        except Exception:
-            return  # mining must never break the session
-        self._saved.add(key)
-        if self.dispatch is not None:
-            self.dispatch(LessonSaved(title, content))
-
-    def _build(self, pitfall: str):
-        s = _active(self.state)
-        task = (s.goal or "").strip()
-        files = sorted(s.edited_files) or list(s.active_files)   # the CHANGE set (what the fix touched)
-        tags = self._tags(files)
-        # D1 — the TITLE is the PITFALL signature + the actual fix, NEVER the raw user goal. The goal
-        # is the verbatim user prompt; titling lessons with it ("Lesson: ok lets create a project…")
-        # makes recall match on phrasing, not on the engineering pitfall a future task should avoid.
-        title = "Lesson: " + pitfall_signature(pitfall, 60)
-        if self.mode == "llm" and self.llm is not None:
-            content = self._distill(task, pitfall, files)
-            if content:
-                return (title, content, tags)
-        # deterministic lesson (default): honest — leads with the PITFALL + the actual fix (the edited
-        # files / change set), with the goal demoted to inline context only (a recall breadcrumb, never
-        # the headline). D2: the pitfall is already filtered (no self-inflicted/harness errors).
-        content = (
-            f"Pitfall: {one_line(pitfall, 200)}\n"
-            f"Fix: edited {', '.join(files) or '(files)'} and verified the task passing.\n"
-            f"Task context: {one_line(task, 120)}\n"
-        )
-        return (title, content, tags)
-
-    def _distill(self, task: str, pitfall: str, files: list[str]) -> str:
-        sys_msg = (
-            "You distill ONE durable, generalizable engineering lesson from a coding "
-            "episode, for a future agent. Output 1-3 sentences. Phrase it as a declarative "
-            "FACT about the code/problem (what was wrong, why, and what the correct approach "
-            "is) — NOT as an imperative to your future self: e.g. 'str_replace no-ops unless "
-            "its snippet is unique' ✓, 'Always add context to str_replace' ✗. Imperatives get "
-            "re-read as directives in later sessions and cause wrong or repeated work. "
-            "No preamble, no markdown."
-        )
-        user = (
-            f"Task: {task}\nError that was hit and then resolved:\n{one_line(pitfall, 2000)}\n"
-            f"Files changed: {', '.join(files) or '(unknown)'}\nWrite the lesson:"
-        )
-        try:
-            resp = self.llm.complete(
-                [{"role": "system", "content": sys_msg}, {"role": "user", "content": user}], []
-            )
-        except Exception:
-            return ""
-        text = (resp.content or "").strip()
-        if not text:
-            return ""
-        return f"Task context: {one_line(task, 120)}\nLesson: {text}\n"
-
-    @staticmethod
-    def _tags(files: list[str]) -> str:
-        import os
-        tags = {"memagent"}
-        for p in files:
-            t = _EXT_TAG.get(os.path.splitext(p)[1])
-            if t:
-                tags.add(t)
-        return ",".join(sorted(tags))
-
-
-def make_miner(memory, state, *, llm=None, mode: str = "deterministic", scope: str = "default"):
-    """Factory. Returns None when there's nothing to write to (NullMemory) — so the
-    sink list stays clean and mining is a true no-op without memem."""
-    if type(memory).__name__ == "NullMemory":
-        return None
-    return LessonMiner(memory, state, llm=llm, mode=mode, scope=scope)

--- a/src/memagent/pagetable.py
+++ b/src/memagent/pagetable.py
@@ -36,14 +36,17 @@ class PageTable:
     backend; ``k`` is the per-kind budget (k<=0 SKIPS that backend, returning [])."""
 
     def __init__(self, retriever=None, memory=None, subdir_hints=None,
-                 *, exclude_session: str | None = None):
+                 *, session_id: str | None = None):
         self.retriever = retriever
         self.memory = memory
         self.subdir_hints = subdir_hints          # OWNED here (per-task subtree dedup lives on it)
-        self.exclude_session = exclude_session     # cross-session reads drop the current lineage
+        # ONE concept — the CURRENT session: cross-session reads EXCLUDE it, within-session reads filter
+        # ONLY to it. (Was the overloaded `exclude_session`, used as both exclude AND only — a leak waiting
+        # to happen the moment a caller left it None.)
+        self.session_id = session_id
 
     # ------------------------------------------------------------------ public
-    def lookup(self, focus, *, kind: str, k: int = 6) -> list[PageRef]:
+    def lookup(self, focus, *, kind: str, k: int = 6, paths=None) -> list[PageRef]:
         """Page in references relevant to ``focus`` from the ``kind`` backend.
 
         ``focus`` is the per-kind locator: a discovery QUERY (code), the active-file WORKING
@@ -57,7 +60,7 @@ class PageTable:
         if kind == "project-notes":
             return self._project_notes(focus)
         if kind == "memory-lessons":
-            return self._lessons(focus, k)
+            return self._lessons(focus, k, paths)
         if kind == "episode-xsession":
             return self._episodes(focus, k)
         if kind == "episode-thissession":
@@ -92,14 +95,14 @@ class PageTable:
         return [PageRef(handle="(project notes)", kind="project-notes", preview=text,
                         score=0.0, untrusted=True)]
 
-    def _lessons(self, query: str, k: int) -> list[PageRef]:
+    def _lessons(self, query: str, k: int, paths=None) -> list[PageRef]:
         """RELEVANT MEMORY: distilled cross-session LESSONS (memem's relevance-gated retrieve), the
         always-on per-turn recall. Distinct from `_episodes` (raw FTS5 episode text): lessons are the
         consolidated long-term vault, episodes are the lossless cache. Each Snippet -> one PageRef
         (preview carries the lesson text RAW; the renderer fences it). memory absent / no hits -> []."""
         if self.memory is None:
             return []
-        snippets = self.memory.recall(query, k=k)
+        snippets = self.memory.recall(query, k=k, paths=paths)   # R1: file-context bonus at topic-start
         return [PageRef(handle=sn.path, kind="memory-lessons", preview=sn.text,
                         score=sn.score, untrusted=True) for sn in snippets]
 
@@ -110,7 +113,7 @@ class PageTable:
         if self.memory is None or not isinstance(query, str) or not query.strip():
             return []
         hits = self.memory.search_episodes(query.strip(), limit=k,
-                                           exclude_session=self.exclude_session)
+                                           exclude_session=self.session_id)   # cross-session: drop my lineage
         return [_episode_pageref(h) for h in hits]
 
     def _episodes_search_thissession(self, query: str, k: int) -> list[PageRef]:
@@ -118,9 +121,9 @@ class PageTable:
         the manifest/index window). Closes the gap where an old turn was reachable only by a turn number
         nobody knew. Each hit -> a PageRef whose handle is the TURN NUMBER, so the model pages the full
         turn with recall_history(turns=[N]) — search by content, fetch by the number it just learned."""
-        if self.memory is None or not isinstance(query, str) or not query.strip():
-            return []
-        hits = self.memory.search_episodes(query.strip(), limit=k, only_session=self.exclude_session)
+        if self.memory is None or not isinstance(query, str) or not query.strip() or not self.session_id:
+            return []                              # FAIL CLOSED: no current session → no within-session search
+        hits = self.memory.search_episodes(query.strip(), limit=k, only_session=self.session_id)
         return [PageRef(handle=str(h.get("turn")), kind="episode-search-thissession",
                         preview=_pack_episode_preview(h), score=float(h.get("score") or 0.0),
                         untrusted=False) for h in hits]

--- a/src/memagent/slice.py
+++ b/src/memagent/slice.py
@@ -836,7 +836,7 @@ def make_build_slice(state, tools, retriever, memory, task: str, session_id: str
     # PageTable — the SINGLE read/retrieval entry: unifies code discovery (retriever), project notes
     # (the SubdirHints above), and cross-session episodes (memory) behind lookup(). Built ONCE per
     # closure; build() drives it. Backends emit RAW text; the renderer fences (one layer).
-    pages = PageTable(retriever, memory, hints)
+    pages = PageTable(retriever, memory, hints, session_id=session_id or None)
     swap = SwapManager(retriever)   # owns the working-set page lifecycle for this session
     # CACHE tier B — RESIDENT REPO MAP: the project's structural map, built ONCE per session (stable →
     # prompt-cache warm) so a broad task navigates from a resident map instead of re-listing/find. Lazy
@@ -891,7 +891,10 @@ def make_build_slice(state, tools, retriever, memory, task: str, session_id: str
         goal = s.goal or task
         if goal not in recall_cache:
             # RELEVANT MEMORY through the ONE read seam (memory-lessons backend) — no sibling recall.
-            recall_cache[goal] = render_memory(pages.lookup(goal, kind="memory-lessons", k=6))
+            # R1: pass the files in play at topic-recall time so memem bonuses lessons tagged with them.
+            # Snapshot-at-first-recall (cached by goal) — keeps the per-topic single memem call stable.
+            _paths = sorted(set(s.edited_files) | set(s.active_files)) or None
+            recall_cache[goal] = render_memory(pages.lookup(goal, kind="memory-lessons", k=6, paths=_paths))
         # the render view budget tracks the LIVE adaptive budget (s.read_budget, grown on refault by
         # SwapManager); OPEN FILES/RECENT/findings are otherwise UNCAPPED (bound = relevance, not size).
         read_budget = s.read_budget

--- a/tests/test_cache_manifest.py
+++ b/tests/test_cache_manifest.py
@@ -148,7 +148,7 @@ def pagetable_memory_lessons_unifies_recall():
     from memagent.slice import render_memory
 
     class _LessonMem:
-        def recall(self, q, k=6):
+        def recall(self, q, k=6, paths=None):
             return [Snippet(path="mem://a", text="lesson  one", score=0.9),
                     Snippet(path="mem://b", text="lesson two", score=0.4)]
         def read_episodes(self, *a, **k): return []

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -8,7 +8,8 @@ import tempfile
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from memagent.consolidate import (  # noqa: E402
-    promote_episodes, promote_procedures, render_skill)
+    build_learn_prompt, promote_episodes, promote_procedures, render_skill, render_skill_llm)
+from memagent.memory import make_write_skill_tool  # noqa: E402
 
 CHECKS = []
 def check(fn):
@@ -81,7 +82,7 @@ def consolidate_reads_cache_if_memem():
         return
     m._vault = tempfile.mkdtemp()
     captured = []
-    m.remember = lambda content, *, title="", scope="default", tags="": captured.append((title, content, tags))
+    m.remember = lambda content, *, title="", scope="default", tags="", paths=None: captured.append((title, content, tags))
     m.append_episode("s1", "t1", 1, {"steps": [{"slice": "", "action": [], "observation": ["Error: boom"]}],
                                      "note": "", "meta": {"failing": True, "stop_reason": "tool_use", "files": ["a.py"]}})
     m.append_episode("s1", "t1", 2, {"steps": [{"slice": "", "action": [], "observation": ["ok"]}],
@@ -150,7 +151,7 @@ def consolidate_routes_facts_and_procedures_if_memem():
     m = MememMemory(); m._vault = tempfile.mkdtemp()
     sk = tempfile.mkdtemp(); os.environ["MEMAGENT_SKILLS_DIR"] = sk
     captured = []
-    m.remember = lambda content, *, title="", scope="default", tags="": captured.append(title)
+    m.remember = lambda content, *, title="", scope="default", tags="", paths=None: captured.append(title)
     try:
         # a corrective FACT episode
         m.append_episode("s1", "t1", 1, {"title": "fix", "steps": [{"slice": "", "action": [], "observation": ["Error: boom"]}],
@@ -169,6 +170,119 @@ def consolidate_routes_facts_and_procedures_if_memem():
         assert skills, "expected a procedure skill written"
         body = open(os.path.join(sk, skills[0], "SKILL.md")).read()  # one PROCEDURE skill
         assert body.startswith("---\nname:") and "## Process" in body and "read_file" in body
+    finally:
+        os.environ.pop("MEMAGENT_SKILLS_DIR", None)
+
+
+# --- R1: lessons tagged with files (paths_context bonus) + paths threaded read-side ---------------
+@check
+def promote_episodes_tags_lesson_with_files():
+    recs = [rec("t1", 1, ["Error: boom"], failing=True, files=["pkg/core.py"]),
+            rec("t1", 2, ["ok"], note="fixed", stop="end_turn", files=["pkg/core.py"])]
+    assert promote_episodes(recs)[0]["files"] == ["pkg/core.py"], "R1: lesson must carry its files for paths"
+
+
+@check
+def lookup_threads_paths_to_recall():
+    from memagent.pagetable import PageTable
+    captured = {}
+    class _M:
+        def recall(self, query, k=6, paths=None):
+            captured["paths"] = paths
+            return []
+    PageTable(memory=_M()).lookup("fix the parser", kind="memory-lessons", k=6, paths=["a.py", "b.py"])
+    assert captured["paths"] == ["a.py", "b.py"], "R1: paths must reach recall (→ retrieve paths_context)"
+
+
+# --- R3: near-duplicate-GOAL workflows collapse to one skill (lexical cluster, no memem) ----------
+@check
+def near_dup_goal_procedures_collapse_to_one():
+    A = [act("read_file", path="a.py"), act("str_replace", path="a.py"), act("run_command", command="t")]
+    B = [act("write_file", path="a.py"), act("append_to_file", path="a.py"), act("run_command", command="t")]
+    recs = [prec("t1", 1, A, files=["a.py"], title="add pagination to the users endpoint"),
+            prec("t2", 1, B, files=["a.py"], title="add pagination to users endpoint handler")]
+    assert len(promote_procedures(recs)) == 1, "same-intent workflows (diff shapes) must collapse to one skill"
+    # distinct intents must NOT collapse
+    recs2 = [prec("t1", 1, A, files=["a.py"], title="add pagination to the users endpoint"),
+             prec("t2", 1, B, files=["b.py"], title="parse the markdown changelog into json")]
+    assert len(promote_procedures(recs2)) == 2, "distinct intents must stay separate"
+
+
+# --- mining behaviour moved from the removed live miner (now owned by promote_episodes) ----------
+@check
+def self_inflicted_episode_mines_nothing():
+    # the agent hit its OWN sandbox (confinement) — not an engineering pitfall → mine NOTHING
+    recs = [rec("t1", 1, ["Error: path escapes the boundary (/repo): /etc/x — File tools are confined"],
+                failing=True, files=["x.py"]),
+            rec("t1", 2, ["ok"], note="moved it", stop="end_turn", files=["x.py"])]
+    assert promote_episodes(recs) == [], "a self-inflicted confinement error must not mine a lesson"
+
+
+@check
+def real_pitfall_chosen_over_self_inflicted():
+    # a turn with BOTH a confinement error AND a real error must mine the REAL one
+    recs = [rec("t1", 1, ["Error: path escapes the boundary (/repo): /etc/x",
+                          "Error: ImportError: cannot import bar"], failing=True, files=["imp.py"]),
+            rec("t1", 2, ["ok"], note="added the missing import", stop="end_turn", files=["imp.py"])]
+    lessons = promote_episodes(recs)
+    assert len(lessons) == 1
+    assert "ImportError" in lessons[0]["content"], f"mined the wrong pitfall: {lessons[0]['content']!r}"
+    assert "escapes the boundary" not in lessons[0]["content"], "self-inflicted error leaked into the lesson"
+
+
+@check
+def fact_title_leads_with_note_or_pitfall_never_the_goal():
+    # the records carry no user goal; the title is the resolution NOTE (or the pitfall), body leads "Pitfall:"
+    recs = [rec("t1", 1, ["Error: ModuleNotFoundError: feedparser"], failing=True, files=["agg.py"]),
+            rec("t1", 2, ["ok"], note="installed feedparser", stop="end_turn", files=["agg.py"])]
+    lessons = promote_episodes(recs)
+    assert len(lessons) == 1
+    title, content = lessons[0]["title"], lessons[0]["content"]
+    assert "installed feedparser" in title or "ModuleNotFoundError" in title, f"weak title: {title!r}"
+    assert content.startswith("Pitfall:"), "the lesson body must LEAD with the pitfall"
+
+
+# --- B1: LLM-generalized skill body (render_skill_llm) + F1 scan-first ---------------------------
+class _StubLLM:
+    def complete(self, msgs, schemas):
+        class R:
+            content = "## When to use\nwhen parsing input\n## Process\n1. read it\n2. transform\n## Pitfalls\nnone known"
+        return R()
+
+
+@check
+def render_skill_llm_generalizes_falls_back_and_scans_first():
+    proc = {"name": "build-parser", "description": "build the parser",
+            "steps": ["read x", "edit y", "run z"], "files": ["p.py"], "freq": 2}
+    g = render_skill_llm(proc, _StubLLM())
+    assert g.startswith("---\nname:") and "## Process" in g and "Generalized" in g, "LLM body not used"
+    assert "## Process (observed)" in render_skill_llm(proc, None), "no-llm must fall back to recorded"
+    sproc = dict(proc, description="use api_key=sk-zzz123456 to build")          # F1
+    assert "## Process (observed)" in render_skill_llm(sproc, _StubLLM()), "secret must skip the LLM"
+
+
+# --- B2: /learn prompt (transcript→skill, cache-sourced) + the foreground write_skill tool --------
+@check
+def learn_prompt_drives_write_skill_from_the_cache():
+    p = build_learn_prompt("")
+    assert "write_skill" in p and "recall_history" in p and "## Process" in p
+    assert "workflow we just went through" in p                                  # default source
+    assert "deploy.md" in build_learn_prompt("the deploy steps in deploy.md")    # honors the user's source
+
+
+@check
+def write_skill_tool_writes_user_provenance_and_validates():
+    sk = tempfile.mkdtemp(); os.environ["MEMAGENT_SKILLS_DIR"] = sk
+    try:
+        tool = make_write_skill_tool()
+        out = tool.handler({"name": "Deploy Flow", "description": "deploy the app to staging",
+                            "body": "## When to use\nbefore a release\n## Process\n1. build\n2. push"})
+        assert "saved" in out.lower(), out
+        import glob
+        body = open(glob.glob(os.path.join(sk, "*", "SKILL.md"))[0]).read()
+        assert "provenance: user" in body and "deploy the app to staging" in body
+        assert "deploy-flow" in body[:80]                                        # name slugged
+        assert "need a name" in tool.handler({"name": "x"}).lower()              # validation
     finally:
         os.environ.pop("MEMAGENT_SKILLS_DIR", None)
 

--- a/tests/test_memory_persist.py
+++ b/tests/test_memory_persist.py
@@ -36,7 +36,7 @@ def _install_fake_memem(fake_save: _FakeSave):
     `from memem.operations import memory_save`, so this is all the surface it needs — no real memem."""
     pkg = types.ModuleType("memem")
     ops = types.ModuleType("memem.operations")
-    def memory_save(content, *, title="", scope_id="default", tags=""):
+    def memory_save(content, *, title="", scope_id="default", tags="", paths=None):
         fake_save.calls.append((content, title, scope_id, tags))
     ops.memory_save = memory_save
     pkg.operations = ops

--- a/tests/test_mining.py
+++ b/tests/test_mining.py
@@ -1,4 +1,7 @@
-"""Mining gate + read-only convergence nudge — the two bugs from the live 'hello'/'show path' run.
+"""Read-only convergence nudge (render_convergence) — the 'show path' spin bug: a read-only task that
+keeps exploring without answering gets nudged to answer/ask, but an edit task, a below-threshold turn,
+an errored turn, and a delegated explorer do NOT. (The lesson-mining half of this file moved to
+test_consolidate.py — distillation is now CACHE-only; the per-turn LessonMiner was removed.)
 No model, no pytest. Run: python tests/test_mining.py
 """
 import os
@@ -6,57 +9,12 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from memagent.events import ToolResult, TurnEnd          # noqa: E402
-from memagent.mining import LessonMiner                  # noqa: E402
 from memagent.slice import EXPLORE_NUDGE_AFTER, Slice, render_convergence  # noqa: E402
 
 CHECKS = []
 def check(fn):
     CHECKS.append(fn)
     return fn
-
-
-class _Mem:
-    is_durable = True
-    def __init__(self):
-        self.saved = []
-    def remember(self, content, *, title="", scope="default", tags=""):
-        self.saved.append((title, content))
-
-
-def _run(state, *, fail_out="Error: boom", clear_error=True):
-    mem = _Mem()
-    miner = LessonMiner(mem, state, mode="deterministic", scope="test")
-    miner(ToolResult("run_command", {"command": "x"}, fail_out, True))   # an error happened
-    if clear_error:
-        state.last_error = ""
-    miner(TurnEnd("end_turn", 1, {}))
-    return mem
-
-
-@check
-def no_edit_no_lesson():
-    # the live bug: read_file on a dir errored, turn ended clean, NOTHING was edited → must NOT mine
-    s = Slice(); s.reset("show me the current file path")          # edited_files empty
-    assert _run(s).saved == []
-
-
-@check
-def edit_present_mines_lesson():
-    s = Slice(); s.reset("fix the parser")
-    s.edited_files = {"parser.py"}
-    mem = _run(s)
-    assert len(mem.saved) == 1
-    title, content = mem.saved[0]
-    assert "boom" in content and "parser.py" in content            # change set in the body
-
-
-@check
-def no_error_no_lesson():
-    s = Slice(); s.reset("t"); s.edited_files = {"a.py"}
-    mem = _Mem(); m = LessonMiner(mem, s, mode="deterministic")
-    m(TurnEnd("end_turn", 1, {}))                                  # no error this turn
-    assert mem.saved == []
 
 
 @check

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -7,8 +7,8 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from memagent.events import AssistantText, ToolResult, TurnEnd  # noqa: E402
-from memagent.mining import LessonMiner, is_self_inflicted, pitfall_signature  # noqa: E402
+from memagent.events import AssistantText, ToolResult  # noqa: E402
+from memagent.mining import is_self_inflicted, pitfall_signature  # noqa: E402
 from memagent.slice import (  # noqa: E402
     SYSTEM_PROMPT, Slice, is_done_claim, record_note, render_findings, render_slice, slice_sink,
 )
@@ -30,14 +30,6 @@ def system_prompt_forbids_narration_in_replies():
     assert "silently" in low or "not shown" in low, "must tell the model to think silently"
     assert "let me" in low and "narrate" in low, "must name the narration anti-pattern explicitly"
     assert "preamble" in low, "must forbid preamble/postamble (lead with the answer)"
-
-
-class _Mem:
-    is_durable = True
-    def __init__(self):
-        self.saved = []
-    def remember(self, content, *, title="", scope="default", tags=""):
-        self.saved.append((title, content))
 
 
 # --- findings come ONLY from notes on real tool calls (NOT assistant narration) ----------
@@ -130,58 +122,9 @@ def slice_tier_reframed_away_from_do_not_rederive():
     assert "verify against OPEN FILES" in user or "ground truth" in user.lower()
 
 
-# --- mining: title from PITFALL not goal; self-inflicted errors mine nothing --------------
-
-def _run_miner(state, *, fail_out, clear_error=True):
-    mem = _Mem()
-    miner = LessonMiner(mem, state, mode="deterministic", scope="test")
-    miner(ToolResult("run_command", {"command": "x"}, fail_out, True))
-    if clear_error:
-        state.last_error = ""
-    miner(TurnEnd("end_turn", 1, {}))
-    return mem
-
-
-@check
-def mined_lesson_titled_by_pitfall_not_goal():
-    s = Slice(); s.reset("ok lets create a simple news aggregator project")
-    s.edited_files = {"news_agg.py"}
-    mem = _run_miner(s, fail_out="Error: ModuleNotFoundError: No module named 'feedparser'")
-    assert len(mem.saved) == 1
-    title, content = mem.saved[0]
-    assert "feedparser" in title or "ModuleNotFoundError" in title, f"title lost the pitfall: {title!r}"
-    assert "create a simple news aggregator" not in title, f"goal leaked into the title: {title!r}"
-    # the goal survives only as inline context, never as the headline
-    assert "Pitfall:" in content and "news_agg.py" in content
-    assert content.startswith("Pitfall:"), "the lesson body must LEAD with the pitfall, not the goal"
-
-
-@check
-def confinement_error_mines_nothing():
-    # the agent hit its OWN sandbox (D2) — that is not an engineering pitfall → mine NOTHING
-    s = Slice(); s.reset("write a file outside the workspace")
-    s.edited_files = {"x.py"}
-    err = ("Error: path escapes the boundary (/repo): ~/Desktop/x.py — File tools are confined "
-           "to the workspace.")
-    mem = _run_miner(s, fail_out=err)
-    assert mem.saved == [], f"a self-inflicted confinement error mined a junk lesson: {mem.saved}"
-
-
-@check
-def real_pitfall_after_self_inflicted_still_mines():
-    # a turn with BOTH a confinement error AND a real error must mine the real one
-    s = Slice(); s.reset("fix the importer")
-    s.edited_files = {"imp.py"}
-    mem = _Mem()
-    miner = LessonMiner(mem, s, mode="deterministic", scope="test")
-    miner(ToolResult("read_file", {"path": "/etc/x"}, "Error: path escapes the boundary (/repo): /etc/x", True))
-    miner(ToolResult("run_command", {"command": "python imp.py"}, "Error: ImportError: cannot import bar", True))
-    s.last_error = ""
-    miner(TurnEnd("end_turn", 1, {}))
-    assert len(mem.saved) == 1
-    title, _ = mem.saved[0]
-    assert "ImportError" in title or "import bar" in title, f"mined the wrong pitfall: {title!r}"
-
+# --- mining behaviour (pitfall-titling, self-inflicted filtering, multi-error pick) moved to
+# test_consolidate.py: distillation is now CACHE-only (the per-turn slice-reading LessonMiner was
+# removed); promote_episodes owns it. The pure helpers below still live in mining.py. ---------
 
 @check
 def is_self_inflicted_and_signature_helpers():

--- a/tests/test_recall_search.py
+++ b/tests/test_recall_search.py
@@ -52,7 +52,7 @@ _ROWS = [
 
 @check
 def thissession_search_returns_turn_numbered_hits_only_for_this_session():
-    pt = PageTable(memory=_FakeMem(_ROWS), exclude_session="S")   # exclude_session carries the current sid
+    pt = PageTable(memory=_FakeMem(_ROWS), session_id="S")        # the CURRENT session id
     mine = pt.lookup("database", kind="episode-search-thissession", k=6)
     # only THIS session (S) matches the content "database" — turn 7. OTHER session is filtered out.
     assert [r.handle for r in mine] == ["7"], [r.handle for r in mine]
@@ -61,7 +61,7 @@ def thissession_search_returns_turn_numbered_hits_only_for_this_session():
 
 @check
 def xsession_search_still_excludes_this_session():
-    pt = PageTable(memory=_FakeMem(_ROWS), exclude_session="S")
+    pt = PageTable(memory=_FakeMem(_ROWS), session_id="S")
     cross = pt.lookup("database", kind="episode-xsession", k=6)
     # cross-session must NOT leak THIS session's turns; only OTHER's turn 9 surfaces.
     assert cross and all("OTHER" in r.handle for r in cross), [r.handle for r in cross]
@@ -70,7 +70,7 @@ def xsession_search_still_excludes_this_session():
 
 @check
 def render_search_emits_the_exact_fetch_call_for_this_session_hits():
-    pt = PageTable(memory=_FakeMem(_ROWS), exclude_session="S")
+    pt = PageTable(memory=_FakeMem(_ROWS), session_id="S")
     mine = pt.lookup("database", kind="episode-search-thissession", k=6)
     cross = pt.lookup("database", kind="episode-xsession", k=6)
     out = render_search(mine, cross)
@@ -81,9 +81,18 @@ def render_search_emits_the_exact_fetch_call_for_this_session_hits():
 
 @check
 def empty_query_is_safe():
-    pt = PageTable(memory=_FakeMem(_ROWS), exclude_session="S")
+    pt = PageTable(memory=_FakeMem(_ROWS), session_id="S")
     assert pt.lookup("   ", kind="episode-search-thissession", k=6) == []
     assert pt.lookup(None, kind="episode-search-thissession", k=6) == []
+
+
+@check
+def thissession_search_fails_closed_without_a_session():
+    # REGRESSION (the cross-session leak the review caught): when PageTable has no current session, a
+    # "this-session" content search must return NOTHING — it must NOT fall through to only_session=None
+    # and leak EVERY session's turns. (Old code overloaded one field as both exclude & only → leaked.)
+    pt = PageTable(memory=_FakeMem(_ROWS))                  # no session_id
+    assert pt.lookup("database", kind="episode-search-thissession", k=6) == [], "within-session must fail closed"
 
 
 @check


### PR DESCRIPTION
## Summary
Enforces the memem layering invariant **slice ─seal→ cache ─distill→ memem ─recall→ slice** and ships the missing transcript→skill function, plus moat-safe borrows.

- **Fix-the-path:** distillation is now **cache-only** — removed the per-turn slice-reading `LessonMiner`; all distill flows through `consolidate.promote_episodes/promote_procedures` (read the cache, never the slice).
- **FIX-NOW:** F1 scan/redact before the distill LLM call *and* on its return body · F2 provenance wording · F3 log the procedure cap.
- **BUILD #3:** B1 real `render_skill_llm` generalization (scan-first, degrades without an LLM) · B2 `/learn` + foreground `write_skill` (USER provenance, guarded write). Live-validated end-to-end.
- **BORROW:** R1 file-context `paths` (cache-stable) · R3 lexical near-dup-goal clustering · R2 `AGENT_MINE` gate. R4/queryless/multi-section deferred (need memem API changes, kept behind the interface).

## Review fix (root-cause)
Adversarial review found `PageTable` overloaded `exclude_session` as both exclude *and* only-filter (a latent cross-session-leak foot-gun). Fixed: one `session_id` field (cross-session EXCLUDES it, within-session filters ONLY to it); within-session search **fails closed** when no session is set.

## Verification
- Offline suite **103/103 green** (added B1/B2/R1/R3 + fail-closed regression).
- Live `/learn` probe **PASS** (DeepSeek).
- See `docs/MEMEM-DIAGNOSIS.md` for the full diagnosis + review verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)